### PR TITLE
feat: spoiler detection

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/SpoilerReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/SpoilerReplacer.kt
@@ -1,0 +1,12 @@
+package com.jaoafa.vcspeaker.tts.replacers
+
+import dev.kord.common.entity.Snowflake
+
+object SpoilerReplacer : BaseReplacer {
+    override val priority = ReplacerPriority.High
+
+    override suspend fun replace(text: String, guildId: Snowflake) = text.replace(
+        Regex("\\|\\|.*?\\|\\|"),
+        "ピー"
+    )
+}


### PR DESCRIPTION
Discord のスポイラー (`||これ||`) 記法に対応しました。
スポイラー内の文章はすべて「ピー」に置き換えられます。