### PR TITLE
perf: add reaction on another thread

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
@@ -52,7 +52,7 @@ class Narrator @OptIn(KordVoice::class) constructor(
             narrator()?.queueSelf(voice)
         }
     }
-    
+
     private val scheduler = Scheduler(player)
 
     /**
@@ -89,11 +89,15 @@ class Narrator @OptIn(KordVoice::class) constructor(
 
         if (replacedText.isBlank()) return
 
-        message?.addReaction("👀")
+        CoroutineScope(Dispatchers.Default).launch {
+            message?.addReaction("👀")
+        }
 
         scheduler.queue(message, replacedText, inlineVoice)
 
-        message?.deleteOwnReaction("👀")
+        CoroutineScope(Dispatchers.Default).launch {
+            message?.deleteOwnReaction("👀")
+        }
     }
 
     /**


### PR DESCRIPTION
メッセージを送信してから読み上げられるまでが遅いことがあるので調査したところ、リアクション処理に時間がかかっていたので別スレッドでやるようにしました。

大体 0.6~0.8 秒位短縮できるはずです。
(リアクション以外の遅延はほとんど API 呼び出しと Lavaplayer のロードだったので、これでまだ遅かったらうーんです)