### PR TITLE
feat: vcテキストチャンネルに画像が投稿された場合に、文字起こしする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,8 @@
 .idea
 build
 
-store
-stores
-cache
+store/
+stores/
+cache/
 config.yml
 test.wav

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,6 @@ COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar
 ENV VCSKT_CONFIG /data/config.yml
 ENV VCSKT_STORE /data/store/
 ENV VCSKT_CACHE /data/cache/
+ENV GOOGLE_APPLICATION_CREDENTIALS /data/google-credential.json
 
 CMD ["java", "-jar", "/app/vcspeaker-kt.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,6 +37,8 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
     implementation("org.reflections:reflections:0.10.2")
+    implementation("com.google.cloud:google-cloud-vision:3.32.0")
+    implementation("com.sksamuel.scrimage:scrimage-core:4.1.1")
 }
 
 tasks.test {

--- a/src/main/kotlin/com/jaoafa/vcspeaker/VCSpeaker.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/VCSpeaker.kt
@@ -41,6 +41,9 @@ object VCSpeaker {
         val aliases = storeFolder + File("aliases.json")
         val voices = storeFolder + File("voices.json")
         val titles = storeFolder + File("titles.json")
+        val visionApiCounter = storeFolder + File("vision-api-counter.json")
+
+        val visionApiCache = storeFolder + File("vision-api") + File("cache")
     }
 
     /**

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/VisionApiCounterStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/VisionApiCounterStore.kt
@@ -1,0 +1,55 @@
+package com.jaoafa.vcspeaker.stores
+
+import com.jaoafa.vcspeaker.VCSpeaker
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import java.text.SimpleDateFormat
+import java.util.*
+
+@Serializable
+data class VisionApiCounterData(
+    /** 年月 (yyyy/MM) */
+    val yearMonth: String,
+    /** リクエスト数 */
+    val count: Int,
+    /** リミット到達日時 */
+    val limitReachedAt: Long? = null
+)
+
+// 月当たり 1000 units だけど余裕をもって
+const val VISION_API_LIMIT = 950
+
+object VisionApiCounterStore : StoreStruct<VisionApiCounterData>(
+    VCSpeaker.Files.visionApiCounter.path,
+    VisionApiCounterData.serializer(),
+    { Json.decodeFromString(this) }
+) {
+    /** 年/月ごとのリクエスト数を取得する */
+    fun find(yearMonth: String) = data.find { it.yearMonth == yearMonth }
+
+    /** 今月のリクエスト数が上限に達しているか */
+    fun isLimitExceeded() = (find(getNowYearMonth())?.count ?: 0) >= VISION_API_LIMIT
+
+    /** リクエスト数をインクリメントする */
+    fun increment() {
+        val yearMonth = getNowYearMonth()
+        val counter = find(yearMonth)
+
+        if (counter != null) {
+            data[data.indexOf(counter)] = counter.copy(count = counter.count + 1)
+        } else {
+            data += VisionApiCounterData(yearMonth, 1)
+        }
+
+        // リクエスト数を超えていたらリミット到達日時を記録する
+        if (isLimitExceeded()) {
+            data[data.indexOf(find(yearMonth)!!)] = find(yearMonth)!!.copy(limitReachedAt = System.currentTimeMillis())
+        }
+
+        write()
+    }
+
+    /** 今月の年/月を取得する */
+    private fun getNowYearMonth() = SimpleDateFormat("yyyy/MM").format(Date())
+}
+

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/VisionApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/VisionApi.kt
@@ -1,0 +1,175 @@
+package com.jaoafa.vcspeaker.tools
+
+import com.google.cloud.vision.v1.*
+import com.google.protobuf.ByteString
+import com.google.rpc.Status
+import com.jaoafa.vcspeaker.VCSpeaker
+import com.jaoafa.vcspeaker.stores.VisionApiCounterStore
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.canvas.drawables.Line
+import com.sksamuel.scrimage.canvas.drawables.Text
+import kotlinx.serialization.Serializable
+import org.apache.commons.codec.digest.DigestUtils
+import java.awt.BasicStroke
+import java.awt.Color
+import java.io.ByteArrayInputStream
+import java.io.File
+import java.net.URLConnection
+
+@Serializable
+data class VisionVertex(
+    val x: Int,
+    val y: Int,
+)
+
+@Serializable
+data class VisionTextAnnotation(
+    val description: String,
+    val locale: String,
+    val score: Float,
+    val vertices: List<VisionVertex>,
+)
+
+class VisionApi {
+    /**
+     * Vision APIにリクエストを送信し、VisionTextAnnotationのリストを取得する。
+     *
+     * @throws VisionApiLimitExceededException 月のリクエスト数が上限に達している場合
+     * @throws VisionApiUnsupportedMimeTypeException サポートされていない MIME タイプの ByteArray が指定された場合
+     * @throws VisionApiErrorException Vision API でエラーが発生した場合
+     */
+    fun getTextAnnotations(binaryArray: ByteArray): List<VisionTextAnnotation> {
+        // MimeTypeを確認し、対応しているか確認する
+        val mimeType = binaryArray.getMimeType()
+        if (mimeType !in setOf(
+                "image/jpeg",
+                "image/png",
+                "image/gif",
+                "image/bmp"
+            )
+        ) {
+            throw VisionApiUnsupportedMimeTypeException(mimeType)
+        }
+
+        val fileHash = DigestUtils.md5Hex(binaryArray)
+
+        // キャッシュフォルダが存在しない場合は作成する
+        if (!VCSpeaker.Files.visionApiCache.exists()) {
+            VCSpeaker.Files.visionApiCache.mkdirs()
+        }
+
+        val cacheFile = VCSpeaker.Files.visionApiCache + File(fileHash)
+        if (cacheFile.exists()) {
+            // キャッシュが存在する場合はキャッシュを返す
+            val response = AnnotateImageResponse.parseFrom(cacheFile.readBytes())
+            return response.textAnnotationsList.map { it.convertVisionTextAnnotation() }
+        }
+
+        if (VisionApiCounterStore.isLimitExceeded()) {
+            throw VisionApiLimitExceededException()
+        }
+
+        // see https://cloud.google.com/vision/docs/samples/vision-quickstart
+        try {
+            val proto = ByteString.copyFrom(binaryArray)
+            val vision = ImageAnnotatorClient.create()
+            val image = Image.newBuilder().setContent(proto).build()
+            val feature = Feature.newBuilder().setType(Feature.Type.TEXT_DETECTION).build()
+            val request = AnnotateImageRequest.newBuilder().addFeatures(feature).setImage(image).build()
+
+            VisionApiCounterStore.increment()
+            val responses = vision.batchAnnotateImages(listOf(request))
+            vision.close()
+            if (responses.responsesCount == 0) {
+                throw Exception("No response")
+            }
+            val response = responses.getResponses(0)
+            if (response.hasError()) {
+                throw VisionApiErrorException(response.error)
+            }
+            // レスポンスの保存
+            response.save(fileHash)
+
+            return response.textAnnotationsList.map { it.convertVisionTextAnnotation() }
+        } catch (e: Throwable) {
+            throw VisionApiUnknownErrorException(e)
+        }
+    }
+
+    /**
+     * Vision APIのキャッシュデータをもとに、画像に対して文字位置を示す画像を生成する。
+     */
+    fun drawTextAnnotations(binaryArray: ByteArray): ImmutableImage {
+        val fileHash = DigestUtils.md5Hex(binaryArray)
+        val cacheFile = VCSpeaker.Files.visionApiCache + File(fileHash)
+        if (!cacheFile.exists()) {
+            throw Exception("Cache file not found")
+        }
+
+        val response = AnnotateImageResponse.parseFrom(cacheFile.readBytes())
+
+        var canvas = ImmutableImage.loader().fromBytes(binaryArray).toCanvas()
+        // 1つ目は全体のテキストなので除外
+        for (textAnnotation in response.textAnnotationsList.drop(1)) {
+            val vertices = textAnnotation.boundingPoly.verticesList
+            val x1 = vertices[0].x
+            val y1 = vertices[0].y
+            val x2 = vertices[2].x
+            val y2 = vertices[2].y
+            // 矩形を描画
+            canvas = canvas.draw(Line(x1, y1, x2, y1) {
+                it.color = Color.RED
+            })
+            canvas = canvas.draw(Line(x2, y1, x2, y2) {
+                it.color = Color.RED
+            })
+            canvas = canvas.draw(Line(x2, y2, x1, y2) {
+                it.color = Color.RED
+            })
+            canvas = canvas.draw(Line(x1, y2, x1, y1) {
+                it.color = Color.RED
+            })
+
+            // 文字列を描画
+            canvas = canvas.draw(Text(textAnnotation.description, x1, y1) {
+                it.stroke = BasicStroke(3f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND)
+                it.color = Color.WHITE
+                it.drawOval(2, 2, 2, 2)
+            })
+        }
+
+        return canvas.image
+    }
+
+    /** ByteArray から Mime Type を取得する */
+    private fun ByteArray.getMimeType(): String {
+        return URLConnection.guessContentTypeFromStream(ByteArrayInputStream(this)) ?: "application/octet-stream"
+    }
+
+    /** EntityAnnotation を VisionTextAnnotation に変換する */
+    private fun EntityAnnotation.convertVisionTextAnnotation(): VisionTextAnnotation {
+        val vertices = this.boundingPoly.verticesList.map { VisionVertex(it.x, it.y) }
+        return VisionTextAnnotation(this.description, this.locale, this.score, vertices)
+    }
+
+    /** AnnotateImageResponse をキャッシュとしてファイルに保存する */
+    private fun AnnotateImageResponse.save(fileHash: String) {
+        val cacheFile = VCSpeaker.Files.visionApiCache + File(fileHash)
+        cacheFile.writeBytes(this.toByteArray())
+    }
+
+    /** Vision API のリクエスト数が上限に達している場合にスローされる例外 */
+    class VisionApiLimitExceededException : Throwable()
+
+    /** Vision API サポート外の MIME タイプが指定された場合にスローされる例外 */
+    class VisionApiUnsupportedMimeTypeException(mimeType: String) : Throwable("Unsupported MIME type: $mimeType")
+
+    /** Vision API のエラー例外 */
+    class VisionApiErrorException(status: Status) : Throwable(status.message)
+
+    /** Vision API の不明なエラー例外 */
+    class VisionApiUnknownErrorException(cause: Throwable) : Throwable(cause)
+
+    /** File の加算拡張関数: `this + file` で `this` と `file` を連結する。 */
+    private operator fun File.plus(file: File) = File(this, file.name)
+}

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/VisionApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/VisionApi.kt
@@ -6,15 +6,15 @@ import com.google.rpc.Status
 import com.jaoafa.vcspeaker.VCSpeaker
 import com.jaoafa.vcspeaker.stores.VisionApiCounterStore
 import com.sksamuel.scrimage.ImmutableImage
-import com.sksamuel.scrimage.canvas.drawables.Line
+import com.sksamuel.scrimage.canvas.drawables.FilledRect
 import com.sksamuel.scrimage.canvas.drawables.Text
 import kotlinx.serialization.Serializable
 import org.apache.commons.codec.digest.DigestUtils
-import java.awt.BasicStroke
 import java.awt.Color
 import java.io.ByteArrayInputStream
 import java.io.File
 import java.net.URLConnection
+import kotlin.math.roundToInt
 
 @Serializable
 data class VisionVertex(
@@ -116,26 +116,24 @@ class VisionApi {
             val y1 = vertices[0].y
             val x2 = vertices[2].x
             val y2 = vertices[2].y
-            // 矩形を描画
-            canvas = canvas.draw(Line(x1, y1, x2, y1) {
-                it.color = Color.RED
-            })
-            canvas = canvas.draw(Line(x2, y1, x2, y2) {
-                it.color = Color.RED
-            })
-            canvas = canvas.draw(Line(x2, y2, x1, y2) {
-                it.color = Color.RED
-            })
-            canvas = canvas.draw(Line(x1, y2, x1, y1) {
-                it.color = Color.RED
-            })
 
-            // 文字列を描画
-            canvas = canvas.draw(Text(textAnnotation.description, x1, y1) {
-                it.stroke = BasicStroke(3f, BasicStroke.CAP_ROUND, BasicStroke.JOIN_ROUND)
-                it.color = Color.WHITE
-                it.drawOval(2, 2, 2, 2)
-            })
+            // フォントサイズは、矩形の高さの 1/2 とする。ただし、最小値は 10 とする。
+            var fontSize = (y2 - y1) / 2f
+            if (fontSize < 10) {
+                fontSize = 10f
+            }
+            canvas = canvas.draw(
+                // 矩形を描画
+                FilledRect(x1, y1, x2 - x1, y2 - y1) {
+                    // グレーの半透明の矩形を描画
+                    it.color = Color(0, 0, 0, 128)
+                },
+                // 文字列を描画
+                Text(textAnnotation.description, x1, (y1 + fontSize).roundToInt()) {
+                    it.color = Color.WHITE
+                    it.font = it.font.deriveFont(fontSize)
+                }
+            )
         }
 
         return canvas.image

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
@@ -54,7 +54,8 @@ object MessageProcessor {
         val binaryArray = firstAttachment.download()
         try {
             val textAnnotations = VisionApi().getTextAnnotations(binaryArray)
-            val firstDescription = textAnnotations.firstOrNull()?.description ?: ""
+            // 改行は半角スペースに置換する
+            val firstDescription = textAnnotations.firstOrNull()?.description?.replace("\n", " ") ?: ""
             val shortDescription =
                 if (firstDescription.length > 20) firstDescription.substring(0, 20) + "..." else firstDescription
             val embedDescription =

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
@@ -1,9 +1,18 @@
 package com.jaoafa.vcspeaker.tts
 
+import com.jaoafa.vcspeaker.tools.VisionApi
+import com.kotlindiscord.kord.extensions.utils.download
+import com.sksamuel.scrimage.ImmutableImage
+import com.sksamuel.scrimage.nio.PngWriter
+import dev.kord.core.behavior.reply
 import dev.kord.core.entity.Message
+import dev.kord.rest.builder.message.EmbedBuilder
+import dev.kord.rest.builder.message.addFile
+import java.io.File
+import java.nio.file.Path
 
 object MessageProcessor {
-    fun processMessage(message: Message?): String? {
+    suspend fun processMessage(message: Message?): String? {
         if (message == null) return null
 
         val stickers = message.stickers
@@ -14,19 +23,103 @@ object MessageProcessor {
             return stickers.joinToString(" ") { "スタンプ ${it.name}" }
 
         if (attachments.isNotEmpty()) {
-            val firstAttachment = attachments.toList().first()
-            val fileType = if (firstAttachment.isImage) "画像" else "添付"
+            val fileText = getReadFileText(message)
 
-            val firstFileRead = "${fileType}ファイル ${firstAttachment.filename}"
-
-            val fullFileRead =
-                if (attachments.size > 1)
-                    "$firstFileRead と${attachments.size - 1}個のファイル"
-                else firstFileRead
-
-            return if (content.isBlank()) fullFileRead else "$content $fullFileRead"
+            return if (content.isBlank()) fileText else "$content $fileText"
         }
 
         return content.ifBlank { null }
+    }
+
+    /**
+     * ファイルについての読み上げ文章を作成する。
+     *
+     * ・画像の場合は画像解析を行い、テキストを取得する。「<テキスト> を含む画像ファイル」という形式で返す。この際、文字起こしした結果を返信する
+     * ・画像の場合で解析対象でないなどの場合、「画像ファイル <ファイル名>」という形式で返す。
+     * ・それ以外のファイルの場合、「添付ファイル <ファイル名>」という形式で返す。
+     */
+    private suspend fun getReadFileText(message: Message): String? {
+        if (message.attachments.isEmpty()) return null
+
+        // 2つ以上のファイルが添付されている場合、2つ目以降は「と 〇〇個のファイル」という形式で返す
+        val moreFileRead = if (message.attachments.size > 1) "と ${message.attachments.size - 1}個のファイル" else ""
+
+        // 1つ目のファイルが画像でなければ、画像解析を行わない
+        val firstAttachment = message.attachments.first()
+        if (!firstAttachment.isImage) {
+            return "添付ファイル ${firstAttachment.filename} $moreFileRead"
+        }
+
+        // 画像解析を行う
+        val binaryArray = firstAttachment.download()
+        try {
+            val textAnnotations = VisionApi().getTextAnnotations(binaryArray)
+            val firstDescription = textAnnotations.firstOrNull()?.description ?: ""
+            val shortDescription =
+                if (firstDescription.length > 20) firstDescription.substring(0, 20) + "..." else firstDescription
+            val embedDescription =
+                if (firstDescription.length > 1000) firstDescription.substring(0, 1000) + "..." else firstDescription
+
+            // 画像解析結果を返信する
+            val editedImage = VisionApi().drawTextAnnotations(binaryArray)
+            val filePath = editedImage.outputTempFile()
+            message.reply {
+                embeds = mutableListOf(
+                    EmbedBuilder().apply {
+                        description = "```$embedDescription```"
+                        thumbnail = EmbedBuilder.Thumbnail().apply {
+                            url = "attachment://${filePath.fileName}"
+                        }
+                    }
+                )
+                addFile(filePath)
+            }
+
+            return "$shortDescription を含む画像ファイル $moreFileRead"
+        } catch (_: VisionApi.VisionApiLimitExceededException) {
+            // 月のリクエスト数が上限に達している場合、ファイル名のみを読み上げる
+            return "画像ファイル ${firstAttachment.filename} $moreFileRead"
+        } catch (_: VisionApi.VisionApiUnsupportedMimeTypeException) {
+            // サポートされていない MIME タイプの ByteArray が指定された場合、ファイル名のみを読み上げる
+            return "画像ファイル ${firstAttachment.filename} $moreFileRead"
+        } catch (error: VisionApi.VisionApiErrorException) {
+            // エラーを通知する
+            message.reply {
+                embeds = mutableListOf(
+                    EmbedBuilder().apply {
+                        title = ":x: 画像解析エラー"
+                        description = "画像解析中にエラーが発生しました。"
+                        field {
+                            name = "エラー内容"
+                            value = error.message.toString()
+                        }
+                    }
+                )
+            }
+
+            return "画像ファイル ${firstAttachment.filename} $moreFileRead"
+        } catch (error: VisionApi.VisionApiUnknownErrorException) {
+            // エラーを通知する
+            message.reply {
+                embeds = mutableListOf(
+                    EmbedBuilder().apply {
+                        title = ":x: 画像解析エラー"
+                        description = "画像解析中に不明なエラーが発生しました。"
+                        field {
+                            name = "エラー内容"
+                            value = error.message.toString()
+                        }
+                    }
+                )
+            }
+
+            return "画像ファイル ${firstAttachment.filename} $moreFileRead"
+        }
+    }
+
+    private fun ImmutableImage.outputTempFile(): Path {
+        val tempFile = File.createTempFile("image", ".png")
+        this.output(PngWriter(), tempFile)
+        return tempFile.toPath()
     }
 }


### PR DESCRIPTION
- close #23 

vcテキストチャンネルに画像を投稿した際、Google Cloud Platform の Cloud Vision API を用いて画像内のテキストを文字起こしし、読み上げます。
また、scrimage ライブラリを用いて画像のテキスト位置に短形を描画し、テキストの位置を判別しやすくした画像を合わせて投稿します。

レスポンスは google-cloud-vision ライブラリが定義するファイル形式（JSONなどではなく、バイナリ）でキャッシュし、md5ハッシュ値が同じ画像の場合は同一レスポンスを返します。
キャッシュファイルは store/vision-api/cache/ に格納するようにしました。

割とやっつけで実装しているので、不足あればご指摘ください。

現時点でわかっている問題点として、明らかに画像の読み込み処理で時間かかって読み上げがちょっと止まるので、何らかの対応が今後必要かなとは思います。