### PR TITLE
fix: フォントエラーを解消

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ build
 store/
 stores/
 cache/
+data/
 config.yml
 test.wav

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM azul/zulu-openjdk-alpine:17-latest as runner
 WORKDIR /app
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache libstdc++
+RUN apk add --no-cache libstdc++ msttcorefonts-installer fontconfig && update-ms-fonts
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar
 


### PR DESCRIPTION
Dockerでの実行時に下記エラーが発生する問題を解消します

> Caused by: java.lang.RuntimeException: Fontconfig head is null, check your fonts or fonts configuration

ref: https://stackoverflow.com/questions/74975762/docker-and-spring-boot-giving-sun-awt-fontconfiguration-head-is-null