### PR TITLE
feat: configure logging by slf4j + log4j 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,8 @@
 build
 
 store/
-stores/
 cache/
 data/
+logs/
+
 config.yml
-test.wav

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.0" />
+    <option name="version" value="1.9.21" />
   </component>
 </project>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.21"
     kotlin("plugin.serialization") version "1.8.0"
     application
 }
@@ -20,26 +20,38 @@ dependencies {
     implementation(kotlin("reflect"))
     implementation("junit:junit:4.13.1")
 
-    implementation("ch.qos.logback:logback-classic:1.3.7")
-    implementation("com.github.aikaterna:lavaplayer-natives:original-SNAPSHOT")
-    implementation("com.github.ajalt.clikt:clikt:4.0.0")
-    implementation("com.kotlindiscord.kord.extensions:kord-extensions:1.6.0-SNAPSHOT")
-    implementation("com.uchuhimo:konf:1.1.2")
-    implementation("dev.arbjerg:lavaplayer:2.0.2")
+    // Logging
+    implementation("org.slf4j:slf4j-api:2.1.0-alpha1")
+    implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.23.1")
+    implementation("org.apache.logging.log4j:log4j-core:2.23.1")
+    implementation("io.github.oshai:kotlin-logging-jvm:6.0.3")
+
+    // Discord Related
     implementation("dev.kord:kord-core:unknown-d-field-fix-SNAPSHOT")
     implementation("dev.kord:kord-core-voice:0.13.1")
     implementation("dev.kord:kord-voice:0.13.1")
+    implementation("com.kotlindiscord.kord.extensions:kord-extensions:1.6.0-SNAPSHOT")
+    implementation("dev.arbjerg:lavaplayer:2.0.2")
+    implementation("com.github.aikaterna:lavaplayer-natives:original-SNAPSHOT")
+
+    // Ktor
     implementation("io.ktor:ktor-client-cio-jvm:2.2.4")
     implementation("io.ktor:ktor-client-cio:2.2.4")
     implementation("io.ktor:ktor-client-content-negotiation:2.3.5")
     implementation("io.ktor:ktor-client-core:2.2.4")
-    implementation("io.sentry:sentry:6.30.0")
-    implementation("net.htmlparser.jericho:jericho-html:3.4")
+
+    // Kotlinx
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+
+    // Other Libraries
+    implementation("io.sentry:sentry:6.30.0")
+    implementation("net.htmlparser.jericho:jericho-html:3.4")
     implementation("org.reflections:reflections:0.10.2")
     implementation("com.google.cloud:google-cloud-vision:3.32.0")
     implementation("com.sksamuel.scrimage:scrimage-core:4.1.1")
+    implementation("com.github.ajalt.clikt:clikt:4.0.0")
+    implementation("com.uchuhimo:konf:1.1.2")
 }
 
 tasks.test {

--- a/src/main/kotlin/com/jaoafa/vcspeaker/Main.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/Main.kt
@@ -16,6 +16,7 @@ import com.sedmelluq.discord.lavaplayer.player.AudioConfiguration
 import com.uchuhimo.konf.Config
 import com.uchuhimo.konf.source.yaml
 import dev.kord.common.entity.Snowflake
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.runBlocking
 import kotlin.io.path.Path
 
@@ -60,9 +61,12 @@ class Main : CliktCommand() {
         envvar = "VCSKT_ENCODING_QUALITY"
     ).int().restrictTo(1..10)
 
-    override fun run() {
-        // Options > Config > Default
+    private val logger = KotlinLogging.logger {}
 
+    override fun run() {
+        logger.info { "Starting VCSpeaker..." }
+
+        // Options > Config > Default
         val config = Config {
             addSpec(TokenSpec)
             addSpec(EnvSpec)

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/Emoji.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/Emoji.kt
@@ -1,5 +1,6 @@
 package com.jaoafa.vcspeaker.tools
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
 import io.ktor.client.request.*
@@ -12,8 +13,10 @@ data class EmojiData(
 )
 
 object Emoji {
+    private val logger = KotlinLogging.logger {}
+
     private var emojis = runBlocking {
-        println("Loading emoji data...")
+        logger.info { "Loading emojis..." }
 
         val client = HttpClient(CIO)
 
@@ -29,7 +32,7 @@ object Emoji {
             EmojiData(emoji, name)
         }
 
-        println("Loaded emoji data.")
+        logger.info { "Loading emojis complete." }
 
         emojiData
     }

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -1,0 +1,21 @@
+<Configuration status="info">
+    <Appenders>
+        <Console name="Console">
+            <PatternLayout pattern="%date{HH:mm:ss.SSS} [%t] %highlight{%level} %logger{1} - %msg%n" disableAnsi="false"/>
+        </Console>
+        <RollingFile name="File"
+                     filePattern="./logs/vcspeaker-%d{yyyy-MM-dd}.log"
+                     immediateFlush="true">
+            <PatternLayout pattern="%date{yyy-MM-dd HH:mm:ss.SSS} [%t] %level %logger{1} - %msg%n"/>
+            <Policies>
+                <TimeBasedTriggeringPolicy/>
+            </Policies>
+        </RollingFile>
+    </Appenders>
+    <Loggers>
+        <Root level="debug">
+            <AppenderRef ref="Console" level="info"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
Log4J を設定してログをちゃんと制御するようにしました。
INFO 以上のログがコンソールに、DEBUG 以上のログがファイル (./logs/vcspeaker-yyyy-mm-dd.log) に出力されます。

Kord (と Extensions) のデバッグログについては、ほぼ使ってないし、本当に出したい開発ログが流れてつらいのでコンソールには出さなくていいかなと思いました。

あと、まだ ./logs ディレクトリをほかの場所に設定できるようにはしていません。
必要なら調べて実装しますが、要りますか？

close #9 