### PR TITLE
chore: fix timezone & make gradle deps cached

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,11 +21,9 @@ FROM azul/zulu-openjdk-alpine:17-latest as runner
 WORKDIR /app
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache libstdc++ msttcorefonts-installer fontconfig && \
-    update-ms-fonts && \
-    apk add --update --no-cache tzdata
-ENV TZ=Asia/Tokyo
-RUN apk del tzdata
+RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig tzdata && \
+    update-ms-fonts
+
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar
 
@@ -33,5 +31,8 @@ ENV VCSKT_CONFIG /data/config.yml
 ENV VCSKT_STORE /data/store/
 ENV VCSKT_CACHE /data/cache/
 ENV GOOGLE_APPLICATION_CREDENTIALS /data/google-credential.json
+ENV TZ Asia/Tokyo
+
+RUN apk del tzdata
 
 CMD ["java", "-jar", "/app/vcspeaker-kt.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,9 @@ WORKDIR /app
 
 # hadolint ignore=DL3018
 RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig tzdata && \
+    cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
+    echo "Asia/Tokyo" > /etc/timezone && \
     update-ms-fonts
-
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ WORKDIR /app
 RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo "Asia/Tokyo" > /etc/timezone && \
+    apk del tzdata && \
     update-ms-fonts
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,4 @@ ENV VCSKT_CACHE /data/cache/
 ENV GOOGLE_APPLICATION_CREDENTIALS /data/google-credential.json
 ENV TZ Asia/Tokyo
 
-RUN apk del tzdata
-
 CMD ["java", "-jar", "/app/vcspeaker-kt.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,26 @@ RUN apk add --no-cache git wget unzip
 WORKDIR /build
 
 COPY gradle gradle
-COPY src src
+
 COPY gradlew build.gradle.kts gradle.properties settings.gradle.kts ./
 
-RUN chmod a+x gradlew && \
-  ./gradlew build
+RUN chmod a+x gradlew
+RUN ./gradlew build || return 0
+
+COPY src src
+
+RUN ./gradlew build
 
 FROM azul/zulu-openjdk-alpine:17-latest as runner
 
 WORKDIR /app
 
 # hadolint ignore=DL3018
-RUN apk add --no-cache libstdc++ msttcorefonts-installer fontconfig && update-ms-fonts
+RUN apk add --no-cache libstdc++ msttcorefonts-installer fontconfig && \
+    update-ms-fonts && \
+    apk add --update --no-cache tzdata
+ENV TZ=Asia/Tokyo
+RUN apk del tzdata
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,4 +3,5 @@ services:
     build: .
     volumes:
       - ./data:/data
+      - ./logs:/app/logs
     init: true


### PR DESCRIPTION
- タイムゾーンを Asia/Tokyo に設定しました。
  (ファイルに書き込む方法はなぜか効かなかったので、ENV に設定するようにしました)
- Gradle が依存ライブラリをダウンロードするところまでを、Docker がキャッシュできるようにしました。
- あと ./logs をボリュームに設定しました。