### PR TITLE
fix: disable VisionAPI if config not exists

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
@@ -51,6 +51,10 @@ object MessageProcessor {
             return "添付ファイル ${firstAttachment.filename} $moreFileRead"
         }
 
+        if (!File(System.getenv("GOOGLE_APPLICATION_CREDENTIALS")).exists()) {
+            return "画像ファイル ${firstAttachment.filename} $moreFileRead"
+        }
+
         // 画像解析を行う
         val binaryArray = firstAttachment.download()
         try {


### PR DESCRIPTION
VisionAPI の設定ファイルが存在しない場合は、画像処理を無効化するようにしました。