### PR TITLE
feat: ツイートに含まれるpic.twitter.comなどのURLを読み上げないように変更

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/models/original/twitter/Tweet.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/models/original/twitter/Tweet.kt
@@ -4,4 +4,5 @@ data class Tweet(
     var authorName: String,
     var html: String,
     var plainText: String,
+    var readText: String,
 )

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
@@ -386,10 +386,10 @@ object UrlReplacer : BaseReplacer {
                 "ユーザー「$userName」のツイートへのリンク"
             )
 
-            val tweetContent = tweet.plainText.substring(
+            val tweetContent = tweet.readText.substring(
                 0,
-                70.coerceAtMost(tweet.plainText.length)
-            ) + if (tweet.plainText.length > 70) " 以下略" else ""
+                70.coerceAtMost(tweet.readText.length)
+            ) + if (tweet.readText.length > 70) " 以下略" else ""
             val replaceTo = "${tweet.authorName.removeEmojis()}のツイート「$tweetContent」へのリンク"
 
             replacedText.replace(matchResult.value, replaceTo)


### PR DESCRIPTION
- close #84

以下のドメインURLについて、ツイート本文に含まれる場合に読み上げないようにします。

- pic.twitter.com
- t.co
- twitter.com

また、ハッシュタグの読み上げについて特殊な読み上げを行うように変更しました。