### PR TITLE
feat: タイトル変更時に変更後のタイトルを読み上げる

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/commands/TitleCommand.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/commands/TitleCommand.kt
@@ -9,6 +9,7 @@ import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.respondEmbed
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.successColor
 import com.jaoafa.vcspeaker.tools.discord.Options
 import com.jaoafa.vcspeaker.tools.discord.SlashCommandExtensions.publicSlashCommand
+import com.jaoafa.vcspeaker.tts.narrators.Narrators.narrator
 import com.kotlindiscord.kord.extensions.commands.converters.impl.optionalChannel
 import com.kotlindiscord.kord.extensions.commands.converters.impl.string
 import com.kotlindiscord.kord.extensions.extensions.Extension
@@ -62,6 +63,8 @@ class TitleCommand : Extension() {
 
                     successColor()
                 }
+
+                guild?.narrator()?.queueSelf("タイトルを「$title」に変更しました。")
             }
         }
     }


### PR DESCRIPTION
- close #86 

`title` コマンドによるタイトル変更時、"タイトルを「*新しいタイトル*」に変更しました。" とシステムメッセージで読み上げるようになります。