### PR TITLE
feat: botがVCに参加・移動・退出した場合に読み上げはしないがメッセージ投稿だけ行う

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/events/VoiceLeaveEvent.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/events/VoiceLeaveEvent.kt
@@ -1,10 +1,11 @@
 package com.jaoafa.vcspeaker.events
 
-import com.jaoafa.vcspeaker.tools.discord.VoiceExtensions.leave
+import com.jaoafa.vcspeaker.VCSpeaker
 import com.jaoafa.vcspeaker.stores.GuildStore
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.autoJoinEnabled
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.isAfk
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.selfVoiceChannel
+import com.jaoafa.vcspeaker.tools.discord.VoiceExtensions.leave
 import com.jaoafa.vcspeaker.tts.narrators.NarrationScripts
 import com.jaoafa.vcspeaker.tts.narrators.Narrator.Companion.announce
 import com.kotlindiscord.kord.extensions.extensions.Extension
@@ -21,15 +22,21 @@ class VoiceLeaveEvent : Extension() {
             // target channel is set
             // user left a voice channel
             check {
-                failIf(event.state.getMember().isBot)
+                // Bot自身の場合は無視
+                failIf(event.state.getMember().id == VCSpeaker.kord.selfId)
+
+                // サーバー設定が存在しない場合は無視
                 val settings = GuildStore.getOrDefault(event.state.guildId)
                 failIf(settings.channelId == null)
+
+                // ボイスチャンネル退出時のみ
                 failIf(event.old?.getChannelOrNull() == null || event.state.getChannelOrNull() != null)
             }
 
             action {
                 val guild = event.state.getGuildOrNull() ?: return@action // checked
                 val member = event.state.getMember()
+                val isOnlyMessage = member.isBot
                 val channelLeft = event.old?.getChannelOrNull() ?: return@action // checked
 
                 val selfChannel = guild.selfVoiceChannel()
@@ -41,7 +48,8 @@ class VoiceLeaveEvent : Extension() {
                 if (channelLeft.isAfk()) {
                     guild.announce(
                         voice = NarrationScripts.userLeftOtherChannel(event.state.getMember(), channelLeft),
-                        text = ":outbox_tray: `@${member.username}` が AFK から退出しました。"
+                        text = ":outbox_tray: `@${member.username}` が AFK から退出しました。",
+                        isOnlyMessage = isOnlyMessage
                     )
                     return@action
                 }
@@ -56,7 +64,8 @@ class VoiceLeaveEvent : Extension() {
                 guild.announce(
                     voice = if (channelLeft == selfChannel) NarrationScripts.userLeft(member)
                     else NarrationScripts.userLeftOtherChannel(member, channelLeft),
-                    text = ":outbox_tray: `@${member.username}` が ${channelLeft.mention} から退出しました。"
+                    text = ":outbox_tray: `@${member.username}` が ${channelLeft.mention} から退出しました。",
+                    isOnlyMessage = isOnlyMessage
                 )
             }
         }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
@@ -40,7 +40,8 @@ class Narrator @OptIn(KordVoice::class) constructor(
         suspend fun Guild.announce(
             voice: String,
             text: String,
-            replier: (suspend (String) -> Unit)? = null
+            replier: (suspend (String) -> Unit)? = null,
+            isOnlyMessage: Boolean = false,
         ) {
             if (replier != null) {
                 replier(text)
@@ -49,7 +50,9 @@ class Narrator @OptIn(KordVoice::class) constructor(
                 channel?.createMessage(text)
             }
 
-            narrator()?.queueSelf(voice)
+            if (!isOnlyMessage) {
+                narrator()?.queueSelf(voice)
+            }
         }
     }
 


### PR DESCRIPTION
- close #87 

BotがVCに参加・移動・退出した場合に、それの読み上げ（ナレーション）はしないものの、メッセージ投稿は行うように変更します。
なお、VCSpeaker本人（Bot自身）の場合は本機能の対象外としています。