### PR TITLE
fix: use conventional-changelog-conventionalcommits v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           extra_plugins: |
-            conventional-changelog-conventionalcommits
+            conventional-changelog-conventionalcommits@^7.0.2
         env:
           GITHUB_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
https://www.npmjs.com/package/conventional-changelog-conventionalcommits?activeTab=versions
タイミング的に、CI が落ちるのは conventional-changelog-conventionalcommits の v8 がリリースされたことが原因だと思われるので、一時的に v7 に固定します。