### PR TITLE
feat: スポイラーファイル投稿時、文字起こしもスポイラーする。日本語フォント対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig tzd
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo "Asia/Tokyo" > /etc/timezone && \
     apk del tzdata && \
+    curl -O https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00301.zip && \
+    mkdir -p /usr/share/fonts/ipa && \
+    unzip -o -d /usr/share/fonts/ipa/ IPAexfont00301.zip "*.ttf" && \
     update-ms-fonts
 
 COPY --from=builder /build/build/libs/vcspeaker-*.jar /app/vcspeaker-kt.jar

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM azul/zulu-openjdk-alpine:17-latest as runner
 WORKDIR /app
 
 # hadolint ignore=DL3018
-RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig tzdata && \
+RUN apk add --update --no-cache libstdc++ msttcorefonts-installer fontconfig curl tzdata && \
     cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
     echo "Asia/Tokyo" > /etc/timezone && \
     apk del tzdata && \

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
@@ -93,11 +93,12 @@ object MessageProcessor {
                 addFile(filePath)
             }
 
-            if (isSpoiler) {
+            return if (isSpoiler) {
                 // スポイラーファイルの場合は、スポイラー画像ファイルとして読み上げ
-                return "スポイラー画像ファイル $moreFileRead"
+                "スポイラー画像ファイル $moreFileRead"
+            } else {
+                "$shortDescription を含む画像ファイル $moreFileRead"
             }
-            return "$shortDescription を含む画像ファイル $moreFileRead"
         } catch (_: VisionApi.VisionApiLimitExceededException) {
             // 月のリクエスト数が上限に達している場合、ファイル名のみを読み上げる
             return "画像ファイル ${firstAttachment.filename} $moreFileRead"

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/MessageProcessor.kt
@@ -56,6 +56,7 @@ object MessageProcessor {
         }
 
         // 画像解析を行う
+        val isSpoiler = firstAttachment.isSpoiler
         val binaryArray = firstAttachment.download()
         try {
             val visionApi = VisionApi()
@@ -69,17 +70,18 @@ object MessageProcessor {
 
             // 画像解析結果を返信する
             val editedImage = visionApi.drawTextAnnotations(binaryArray)
-            val filePath = editedImage.outputTempFile()
+            val filePath = editedImage.outputTempFile(isSpoiler)
             val visionApiCounterStore = VisionApiCounterStore.get()
 
             val requestedCount = visionApiCounterStore?.count ?: 0
             val requestLimit = VisionApiCounterStore.VISION_API_LIMIT
             val remainingRequests = requestLimit - requestedCount
 
+            val spoilerPrefixSuffix = if (isSpoiler) "||" else ""
             message.reply {
                 embeds = mutableListOf(
                     EmbedBuilder().apply {
-                        description = "```$embedDescription```"
+                        description = "$spoilerPrefixSuffix```$embedDescription```$spoilerPrefixSuffix"
                         thumbnail = EmbedBuilder.Thumbnail().apply {
                             url = "attachment://${filePath.fileName}"
                         }
@@ -91,6 +93,10 @@ object MessageProcessor {
                 addFile(filePath)
             }
 
+            if (isSpoiler) {
+                // スポイラーファイルの場合は、スポイラー画像ファイルとして読み上げ
+                return "スポイラー画像ファイル $moreFileRead"
+            }
             return "$shortDescription を含む画像ファイル $moreFileRead"
         } catch (_: VisionApi.VisionApiLimitExceededException) {
             // 月のリクエスト数が上限に達している場合、ファイル名のみを読み上げる
@@ -133,8 +139,9 @@ object MessageProcessor {
         }
     }
 
-    private fun ImmutableImage.outputTempFile(): Path {
-        val tempFile = File.createTempFile("image", ".png")
+    private fun ImmutableImage.outputTempFile(isSpoiler: Boolean): Path {
+        val prefix = if (isSpoiler) "SPOILER_" else "Image_"
+        val tempFile = File.createTempFile(prefix, ".png")
         this.output(PngWriter(), tempFile)
         return tempFile.toPath()
     }


### PR DESCRIPTION
スポイラーされた画像ファイルが投稿されたとき、以下のように処理します。

- 文字起こしのメッセージでは、descriptionをスポイラーします。
- 読み上げでは、「スポイラー画像ファイル」として読み上げます。

![image](https://github.com/jaoafa/VCSpeaker.kt/assets/8929706/fecfd630-2557-4650-9de6-6516e544e292)

あわせて、文字起こしメッセージ投稿とあわせてサムネイル投稿される文字箇所画像の日本語が豆腐になる問題を改善しました。