### PR TITLE
fix: specify tag sha of release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,5 +152,6 @@ jobs:
         with:
           body: ${{ needs.bump-version.outputs.changelog }}
           tag_name: ${{ needs.bump-version.outputs.tag }}
+          target_commitish: ${{ github.ref }}
           files: |
             build/libs/vcspeaker-kt.jar


### PR DESCRIPTION
Semantic Release でのバージョン決定とリリースの間のタイミングで次のコミットがされると、それにタグがついて次のリリースが失敗する問題を修正しました。
(ブランチ名を修正)