### PR TITLE
chore: renovate設定内容の変更

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base"
-  ]
+  "extends": ["config:base", ":disableRateLimiting"],
+  "timezone": "Asia/Tokyo",
+  "automerge": true,
+  "platformAutomerge": true,
+  "platformCommit": true
 }


### PR DESCRIPTION
renovateの設定について、以下の変更を加えます。

- extends -> `:disableRateLimiting` の追加
  - アクティブなプルリクエスト3つという制限を外します
- timezone
  - Asia/Tokyoにタイムゾーンを設定します
- automerge & platformAutomerge
  - オートマージを有効にします
  - ただし、`kentaro-m/auto-assign-action` によって強制的にレビュアー追加がなされるため、そのレビュアーがレビューをしない限りマージされることはありません
  - platformAutomergeを有効にすることで、GitHubのAutomerge機能が動作し、レビュー完了 & CIエラーなしだったら即マージされるようになります（レビューApprove後にマージボタンを押下する必要がなくなる）
- platformCommit
  - GitHubプラットフォームのコミットAPIに即するため、署名がされるようになります（たぶん）