### PR TITLE
ci: リリース時のコミット指定をハッシュに変更

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,6 @@ jobs:
         with:
           body: ${{ needs.bump-version.outputs.changelog }}
           tag_name: ${{ needs.bump-version.outputs.tag }}
-          target_commitish: ${{ github.ref }}
+          target_commitish: ${{ github.sha }}
           files: |
             build/libs/vcspeaker-kt.jar


### PR DESCRIPTION
リリース時のコミット指定がrefなことにより、"refs/heads/main" に対してタグ付けがなされている
これにより、リリース処理中に新しくコミットがマージされると、本来と異なるコミットに紐づいてしまうため、github.refではなくgithub.shaでなければだめそう。