### PR TITLE
chore(renovate): mkdocs関連をグループ化

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,12 @@
   "timezone": "Asia/Tokyo",
   "automerge": true,
   "platformAutomerge": true,
-  "platformCommit": true
+  "platformCommit": true,
+  "packageRules": [
+    {
+      "groupName": "mkdocs",
+      "matchPackageNames": ["mkdocs"],
+      "matchPackagePatterns": ["^mkdocs-"]
+    }
+  ]
 }


### PR DESCRIPTION
mkdocs 関連の renovate updates をひとつの PR にグルーピングします。
これにより、mkdocs 本体の更新に依存するアップデート時にエラーにならなくなります。