### PR TITLE
fix: サーバ絵文字のエイリアスが機能しない問題の修正

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/EmojiReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/EmojiReplacer.kt
@@ -8,7 +8,7 @@ import dev.kord.common.entity.Snowflake
  * 絵文字エイリアスを置換するクラス
  */
 object EmojiReplacer : BaseReplacer {
-    override val priority = ReplacerPriority.Normal
+    override val priority = ReplacerPriority.High
 
     override suspend fun replace(tokens: MutableList<Token>, guildId: Snowflake) =
         replaceText(tokens, guildId, AliasType.Emoji) { alias, replacedTokens ->


### PR DESCRIPTION
- close #160 

PriorityがGuildEmojiReplacerと同じになっていた影響で、サーバ絵文字のエイリアスが機能しない問題を改善します。
※このあたりの複合テスト、不足しているので別のPRで追加したいですね