### PR TITLE
chore(deps): remove lavaplayer native

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
     implementation("dev.kord:kord-voice:0.13.1")
     implementation("com.kotlindiscord.kord.extensions:kord-extensions:1.6.0")
     implementation("dev.arbjerg:lavaplayer:2.2.1")
-    implementation("com.github.aikaterna:lavaplayer-natives:original-SNAPSHOT")
 
     // Ktor
     implementation("io.ktor:ktor-client-cio-jvm:2.3.11")


### PR DESCRIPTION
lavaplayer に natives が統合されたので、別で入れていた natives の依存を消去しました。(lavalink-devs/lavaplayer の # 2)