### PR TITLE
fix: italic bold fails

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,7 +47,7 @@ jobs:
       matrix:
         include:
         - language: java-kotlin
-          build-mode: autobuild
+          build-mode: manual
         # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
@@ -73,6 +73,14 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - name: Restore caches
+      uses: actions/cache@v4
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
     # If the analyze step fails for one of the languages you are analyzing with
     # "We were unable to automatically build your code", modify the matrix above
     # to set the build mode to "manual" for that language. Then modify this step
@@ -81,12 +89,7 @@ jobs:
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
     - if: matrix.build-mode == 'manual'
       run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
+        gradle build
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Inline.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Inline.kt
@@ -54,7 +54,7 @@ data class Inline(val text: String, val effects: MutableSet<InlineEffect>) {
                     }
                 }
 
-                closedEffects.forEach { effects.remove(it) != null }
+                closedEffects.forEach { effects.remove(it) }
                 stack = ""
                 closeEffectStack = ""
             }
@@ -78,11 +78,16 @@ data class Inline(val text: String, val effects: MutableSet<InlineEffect>) {
                         processEffect()
                         closeMayFinish = false
                     } else if (stack.isEmpty() && startEffectStack.isNotEmpty()) { // start effect finished
+                        var effectStack = startEffectStack
+
                         for ((marker, effect) in markers) {
-                            if (startEffectStack.endsWith(marker)) {
+                            if (effectStack.endsWith(marker)) {
                                 effects[effect] = inlines.size
+                                effectStack = effectStack.removeSuffix(marker)
                             }
                         }
+
+                        stack += effectStack // ineffective marker
                     }
 
                     stack += char

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Inline.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Inline.kt
@@ -1,5 +1,19 @@
 package com.jaoafa.vcspeaker.tts.markdown
 
+enum class InlineEffect {
+    Code, Bold, Underline, Italic, Strikethrough, Spoiler,
+}
+
+val markers = mapOf(
+    "`" to InlineEffect.Code,
+    "**" to InlineEffect.Bold,
+    "__" to InlineEffect.Underline,
+    "*" to InlineEffect.Italic,
+    "_" to InlineEffect.Italic,
+    "~~" to InlineEffect.Strikethrough,
+    "||" to InlineEffect.Spoiler
+)
+
 data class Inline(val text: String, val effects: MutableSet<InlineEffect>) {
     companion object {
         private val linkRegex = Regex("\\[(?<text>((?!https?://).)+?)]\\(<?(?<url>https?://.+?)>?\\)")
@@ -82,17 +96,3 @@ data class Inline(val text: String, val effects: MutableSet<InlineEffect>) {
         }
     }
 }
-
-enum class InlineEffect {
-    Code, Bold, Underline, Italic, Strikethrough, Spoiler,
-}
-
-val markers = mapOf(
-    "`" to InlineEffect.Code,
-    "**" to InlineEffect.Bold,
-    "__" to InlineEffect.Underline,
-    "*" to InlineEffect.Italic,
-    "_" to InlineEffect.Italic,
-    "~~" to InlineEffect.Strikethrough,
-    "||" to InlineEffect.Spoiler
-)

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Line.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Line.kt
@@ -26,11 +26,8 @@ data class Line(val inlines: List<Inline>, val effects: Set<LineEffect>) {
         }
     }
 
-    fun toReadable() = inlines.joinToString("") {
-        it.effects.fold(it.text) { text, effect ->
-            //TODO effect.replacer?.invoke(text) ?: text
-            text
-        }
+    fun toReadable(transform: (Inline) -> String) = inlines.joinToString("") {
+        transform(it)
     }
 }
 

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Line.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/markdown/Line.kt
@@ -28,7 +28,8 @@ data class Line(val inlines: List<Inline>, val effects: Set<LineEffect>) {
 
     fun toReadable() = inlines.joinToString("") {
         it.effects.fold(it.text) { text, effect ->
-            effect.replacer?.invoke(text) ?: text
+            //TODO effect.replacer?.invoke(text) ?: text
+            text
         }
     }
 }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/processors/MarkdownFormatProcessor.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/processors/MarkdownFormatProcessor.kt
@@ -1,6 +1,7 @@
 package com.jaoafa.vcspeaker.tts.processors
 
 import com.jaoafa.vcspeaker.tts.Voice
+import com.jaoafa.vcspeaker.tts.markdown.InlineEffect
 import com.jaoafa.vcspeaker.tts.markdown.LineEffect
 import com.jaoafa.vcspeaker.tts.markdown.toMarkdown
 import dev.kord.core.entity.Message
@@ -22,7 +23,17 @@ class MarkdownFormatProcessor : BaseProcessor() {
             }
         } else voice
 
-        val readableMarkdown = markdown.joinToString(" ") { it.toReadable() }
+        val readableMarkdown = markdown.joinToString(" ") { line ->
+            line.toReadable {
+                if (it.effects.contains(InlineEffect.Spoiler)) {
+                    "ピー"
+                } else if (it.effects.contains(InlineEffect.Strikethrough)) {
+                    "パー"
+                } else {
+                    it.text
+                }
+            }
+        }
 
         return readableMarkdown to newVoice
     }

--- a/src/test/kotlin/processors/markdown/InlineTest.kt
+++ b/src/test/kotlin/processors/markdown/InlineTest.kt
@@ -1,0 +1,47 @@
+package processors.markdown
+
+import com.jaoafa.vcspeaker.tts.markdown.Inline
+import com.jaoafa.vcspeaker.tts.markdown.InlineEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class InlineTest : FunSpec({
+    test("Italic-underline overlap") {
+        val inlines = Inline.from("___italic underline___")
+        inlines shouldBe listOf(
+            Inline("italic underline", mutableSetOf(InlineEffect.Italic, InlineEffect.Underline))
+        )
+    }
+
+    test("Italic-bold overlap") {
+        val inlines = Inline.from("***italic bold***")
+        inlines shouldBe listOf(
+            Inline("italic bold", mutableSetOf(InlineEffect.Italic, InlineEffect.Bold))
+        )
+    }
+
+    test("Italic-underline partial overlap") {
+        val inlines = Inline.from("___italic_ underline__")
+        inlines shouldBe listOf(
+            Inline("italic", mutableSetOf(InlineEffect.Italic, InlineEffect.Underline)),
+            Inline(" underline", mutableSetOf(InlineEffect.Underline))
+        )
+    }
+
+    test("Italic-bold partial overlap") {
+        val inlines = Inline.from("***italic* bold**")
+        inlines shouldBe listOf(
+            Inline("italic", mutableSetOf(InlineEffect.Italic, InlineEffect.Bold)),
+            Inline(" bold", mutableSetOf(InlineEffect.Bold))
+        )
+    }
+
+    test("No overlap") {
+        val inlines = Inline.from("**bold** ||spoiler||")
+        inlines shouldBe listOf(
+            Inline("bold", mutableSetOf(InlineEffect.Bold)),
+            Inline(" ", mutableSetOf()),
+            Inline("spoiler", mutableSetOf(InlineEffect.Spoiler))
+        )
+    }
+})

--- a/src/test/kotlin/processors/markdown/LineTest.kt
+++ b/src/test/kotlin/processors/markdown/LineTest.kt
@@ -1,0 +1,80 @@
+package processors.markdown
+
+import com.jaoafa.vcspeaker.tts.markdown.Inline
+import com.jaoafa.vcspeaker.tts.markdown.Line
+import com.jaoafa.vcspeaker.tts.markdown.LineEffect
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class LineTest: FunSpec({
+    test("Headers") {
+        val h1 = Line.from("# Header 1")
+        val h2 = Line.from("## Header 2")
+        val h3 = Line.from("### Header 3")
+        val h4 = Line.from("#### Header 4")
+        val h5 = Line.from("##### Header 5")
+
+        h1 shouldBe Line(
+            Inline.from("Header 1"),
+            setOf(LineEffect.Heading1)
+        )
+
+        h2 shouldBe Line(
+            Inline.from("Header 2"),
+            setOf(LineEffect.Heading2)
+        )
+
+        h3 shouldBe Line(
+            Inline.from("Header 3"),
+            setOf(LineEffect.Heading3)
+        )
+
+        h4 shouldBe Line(Inline.from("#### Header 4"), setOf())
+
+        h5 shouldBe Line(Inline.from("##### Header 5"), setOf())
+    }
+
+    test("Small heading") {
+        val smallHeading = Line.from("-# Small Heading")
+
+        smallHeading shouldBe Line(
+            Inline.from("Small Heading"),
+            setOf(LineEffect.SmallHeading)
+        )
+    }
+
+    test("Quote") {
+        val quote = Line.from("> Quote")
+
+        quote shouldBe Line(
+            Inline.from("Quote"),
+            setOf(LineEffect.Quote)
+        )
+    }
+
+    test("Bullet list") {
+        val bulletList = Line.from("* Bullet List")
+        val bulletListAlt = Line.from("- Bullet List")
+
+        bulletList shouldBe Line(
+            Inline.from("Bullet List"),
+            setOf(LineEffect.BulletList)
+        )
+
+        bulletListAlt shouldBe Line(
+            Inline.from("Bullet List"),
+            setOf(LineEffect.BulletList)
+        )
+    }
+
+    test("Numbered list") {
+        for (i in 1..99) {
+            val numberedList = Line.from("$i. Numbered List")
+
+            numberedList shouldBe Line(
+                Inline.from("Numbered List"),
+                setOf(LineEffect.NumberedList)
+            )
+        }
+    }
+})


### PR DESCRIPTION
close https://github.com/jaoafa/jao-Minecraft-Server/issues/219

メッセージ内に `***text***` `___text___` が含まれている時に読み上げが失敗する問題を修正しました。
あとついでですが、スポイラーと取り消し線を「ピー」と「パー」に置き換える処理を Processor に移動しました。