### PR TITLE
fix(deps): rollback cloud vision to 3.47.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("io.sentry:sentry:7.18.0")
     implementation("org.jsoup:jsoup:1.18.2")
     implementation("org.reflections:reflections:0.10.2")
-    implementation("com.google.cloud:google-cloud-vision:3.52.0")
+    implementation("com.google.cloud:google-cloud-vision:3.47.0")
     implementation("com.sksamuel.scrimage:scrimage-core:4.3.0")
     implementation("com.github.ajalt.clikt:clikt:5.0.1")
     implementation("com.uchuhimo:konf:1.1.2")


### PR DESCRIPTION
Fatal Error が発生するので、最後に正常に機能していたであろう 3.47.0 までロールバックします。
3.47.0 -> 3.50.0 に上げてたので 3.48.0 か 3.49.0 でも良いかもしれませんが... (https://github.com/jaoafa/VCSpeaker.kt/commit/c56101075e10c3ecdf0b4dda7038017ad8172047)