### PR TITLE
fix: ignore exceptions of blocked reactions

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordExtensions.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordExtensions.kt
@@ -2,19 +2,13 @@ package com.jaoafa.vcspeaker.tools.discord
 
 import com.jaoafa.vcspeaker.VCSpeaker
 import com.jaoafa.vcspeaker.stores.GuildStore
-import dev.kordex.core.commands.Arguments
-import dev.kordex.core.commands.application.slash.PublicSlashCommandContext
-import dev.kordex.core.commands.chat.ChatCommandContext
-import dev.kordex.core.types.PublicInteractionContext
-import dev.kordex.core.utils.hasPermission
-import dev.kordex.core.utils.respond
-import dev.kordex.core.utils.selfMember
 import dev.kord.common.Color
 import dev.kord.common.entity.ChannelType
 import dev.kord.common.entity.Permission
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.behavior.GuildBehavior
 import dev.kord.core.behavior.MemberBehavior
+import dev.kord.core.behavior.MessageBehavior
 import dev.kord.core.behavior.UserBehavior
 import dev.kord.core.behavior.channel.BaseVoiceChannelBehavior
 import dev.kord.core.behavior.channel.asChannelOf
@@ -25,8 +19,17 @@ import dev.kord.core.entity.channel.VoiceChannel
 import dev.kord.rest.builder.message.EmbedBuilder
 import dev.kord.rest.builder.message.create.FollowupMessageCreateBuilder
 import dev.kord.rest.builder.message.embed
+import dev.kord.rest.request.KtorRequestException
+import dev.kordex.core.commands.Arguments
+import dev.kordex.core.commands.application.slash.PublicSlashCommandContext
+import dev.kordex.core.commands.chat.ChatCommandContext
+import dev.kordex.core.types.PublicInteractionContext
+import dev.kordex.core.utils.*
+import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.flow.count
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 typealias Options = Arguments
 
@@ -34,6 +37,8 @@ typealias Options = Arguments
  * Discord 関連の拡張関数をまとめたオブジェクト。
  */
 object DiscordExtensions {
+    private val logger = KotlinLogging.logger { }
+
     fun Guild.getSettings() = GuildStore.getOrDefault(this.id)
 
     /**
@@ -194,6 +199,28 @@ object DiscordExtensions {
             0
         } else {
             (goLiveMemberCount.toDouble() / memberCount * 100).toInt()
+        }
+    }
+
+    fun MessageBehavior.addReactionSafe(emoji: String) {
+        runBlocking {
+            launch {
+                try {
+                    addReaction(emoji)
+                } catch (e: KtorRequestException) {
+                    if (e.httpResponse.status.value == 403)
+                        logger.warn { "Reaction to the message $id blocked. Ignoring..." }
+                    else throw e
+                }
+            }
+        }
+    }
+
+    fun MessageBehavior.deleteOwnReactionSafe(emoji: String) {
+        runBlocking {
+            launch {
+                deleteOwnReaction(emoji)
+            }
         }
     }
 }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordExtensions.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordExtensions.kt
@@ -209,7 +209,7 @@ object DiscordExtensions {
                     addReaction(emoji)
                 } catch (e: KtorRequestException) {
                     if (e.httpResponse.status.value == 403)
-                        logger.warn { "Reaction to the message $id blocked. Ignoring..." }
+                        logger.warn { "Reaction Denied: ${e.message}. Message ID: $id. Ignoring..." }
                     else throw e
                 }
             }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/Scheduler.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/Scheduler.kt
@@ -1,5 +1,7 @@
 package com.jaoafa.vcspeaker.tts
 
+import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.addReactionSafe
+import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.deleteOwnReactionSafe
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.errorColor
 import com.jaoafa.vcspeaker.tools.discord.VoiceExtensions.speak
 import com.jaoafa.vcspeaker.tts.providers.BatchProvider
@@ -12,9 +14,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import dev.kord.core.behavior.reply
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Message
-import dev.kord.core.entity.ReactionEmoji
 import dev.kord.rest.builder.message.embed
-import dev.kordex.core.utils.addReaction
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.plugins.*
 import kotlinx.coroutines.launch
@@ -172,9 +172,7 @@ class Scheduler(
                 return@runBlocking
             }
 
-            launch {
-                message?.deleteOwnReaction(ReactionEmoji.Unicode("🔊"))
-            }
+            message?.deleteOwnReactionSafe("🔊")
 
             queue.removeFirst()
             val nextSpeech = current()
@@ -199,9 +197,8 @@ class Scheduler(
      * @param speech 音声
      */
     private fun beginSpeech(speech: Speech): Unit = runBlocking {
-        launch {
-            if (speech.message != null) speech.message.addReaction("🔊")
-        }
+        if (speech.message != null) speech.message.addReactionSafe("🔊")
+
         player.speak(speech)
     }
 }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/narrators/Narrator.kt
@@ -3,7 +3,9 @@ package com.jaoafa.vcspeaker.tts.narrators
 import com.jaoafa.vcspeaker.VCSpeaker
 import com.jaoafa.vcspeaker.stores.GuildStore
 import com.jaoafa.vcspeaker.stores.VoiceStore
+import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.addReactionSafe
 import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.asChannelOf
+import com.jaoafa.vcspeaker.tools.discord.DiscordExtensions.deleteOwnReactionSafe
 import com.jaoafa.vcspeaker.tools.getClassesIn
 import com.jaoafa.vcspeaker.tts.Scheduler
 import com.jaoafa.vcspeaker.tts.SpeechActor
@@ -18,14 +20,8 @@ import dev.kord.common.annotation.KordVoice
 import dev.kord.common.entity.Snowflake
 import dev.kord.core.entity.Guild
 import dev.kord.core.entity.Message
-import dev.kord.core.entity.ReactionEmoji
 import dev.kord.core.entity.channel.TextChannel
 import dev.kord.voice.VoiceConnection
-import dev.kordex.core.utils.addReaction
-import dev.kordex.core.utils.deleteOwnReaction
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
 import kotlin.reflect.full.createInstance
 
 /**
@@ -125,15 +121,11 @@ class Narrator @OptIn(KordVoice::class) constructor(
 
         if (contexts.isEmpty()) return
 
-        CoroutineScope(Dispatchers.Default).launch {
-            message?.addReaction("👀")
-        }
+        message?.addReactionSafe("👀")
 
         scheduler.queue(contexts, message, guild, actor)
 
-        CoroutineScope(Dispatchers.Default).launch {
-            message?.deleteOwnReaction("👀")
-        }
+        message?.deleteOwnReactionSafe("👀")
     }
 
     /**
@@ -169,11 +161,9 @@ class Narrator @OptIn(KordVoice::class) constructor(
      * キューをクリアします。
      */
     fun clear() {
-        CoroutineScope(Dispatchers.Default).launch {
-            listOfNotNull(*scheduler.queue.toTypedArray(), scheduler.current()).forEach {
-                it.message?.deleteOwnReaction(ReactionEmoji.Unicode("🔊"))
-                it.message?.deleteOwnReaction(ReactionEmoji.Unicode("👀"))
-            }
+        listOfNotNull(*scheduler.queue.toTypedArray(), scheduler.current()).forEach {
+            it.message?.deleteOwnReactionSafe("🔊")
+            it.message?.deleteOwnReactionSafe("👀")
         }
 
         scheduler.queue.clear()


### PR DESCRIPTION
close #298 

Bot がブロックされている時、リアクションを付けようとする際に例外が発生する問題を修正しました。

![CleanShot 2025-03-16 at 2  12 26@2x](https://github.com/user-attachments/assets/9f5054ce-11b7-4e94-893d-dda99e267063)
