### PR TITLE
fix: connect timeout, non-existent domains

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
@@ -21,6 +21,7 @@ import dev.kord.core.entity.channel.thread.ThreadChannel
 import io.ktor.client.*
 import io.ktor.client.call.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.network.sockets.*
 import io.ktor.client.plugins.*
 import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
@@ -382,12 +383,14 @@ object UrlReplacer : BaseReplacer {
     /**
      * URLから拡張子を取得します。
      */
-    private fun getExtension(url: String) = try {
-        val path = Url(url).segments.last()
-        val dotPath = path.split(".")
-        if (dotPath.size > 1) dotPath.last() else null
-    } catch (e: MalformedURLException) {
-        null
+    private fun getExtension(url: String): String? {
+        try {
+            val path = Url(url).segments.lastOrNull() ?: return null
+            val dotPath = path.split(".")
+            return if (dotPath.size > 1) dotPath.last() else null
+        } catch (e: MalformedURLException) {
+            return null
+        }
     }
 
     /**
@@ -628,9 +631,12 @@ object UrlReplacer : BaseReplacer {
         urlRegex.replaceAll(text) { replacedText, matchResult ->
             val url = matchResult.value
 
-            val title = getPageTitle(url)?.shorten(30) ?: return@replaceAll replacedText
-
-            val replaceTo = "Webページ「$title」へのリンク"
+            val replaceTo = try {
+                val title = getPageTitle(url)?.shorten(30) ?: return@replaceAll replacedText
+                "Webページ「$title」へのリンク"
+            } catch (_: ConnectTimeoutException) {
+                "存在しないWebページへのリンク"
+            }
 
             replacedText.replace(matchResult.value, replaceTo)
         }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/UrlReplacer.kt
@@ -27,6 +27,7 @@ import io.ktor.client.plugins.contentnegotiation.*
 import io.ktor.client.request.*
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
+import io.ktor.util.network.*
 import io.ktor.utils.io.*
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.io.readByteArray
@@ -635,6 +636,8 @@ object UrlReplacer : BaseReplacer {
                 val title = getPageTitle(url)?.shorten(30) ?: return@replaceAll replacedText
                 "Webページ「$title」へのリンク"
             } catch (_: ConnectTimeoutException) {
+                "存在しないWebページへのリンク"
+            } catch (_: UnresolvedAddressException) {
                 "存在しないWebページへのリンク"
             }
 

--- a/src/test/kotlin/replacers/UrlReplacerTest.kt
+++ b/src/test/kotlin/replacers/UrlReplacerTest.kt
@@ -980,9 +980,26 @@ class UrlReplacerTest : FunSpec({
             }
 
             val tokens =
-                mutableListOf(TextToken("https://example.com explains why https://www.iana.org/help/example-domains is reserved."))
+                mutableListOf(TextToken("https://www.iana.org/help/example-domains explains why https://example.com is reserved."))
             val expectedTokens =
-                mutableListOf(TextToken("Webページ「Example Domain」へのリンク explains why Webページ「Example Domains」へのリンク is reserved."))
+                mutableListOf(TextToken("Webページ「Example Domains」へのリンク explains why Webページ「Example Domain」へのリンク is reserved."))
+
+            val processedTokens = UrlReplacer.replace(
+                tokens, Snowflake(0)
+            )
+
+            processedTokens shouldBe expectedTokens
+        }
+
+        // 存在しないドメイン
+        test("If the domain does not exist, read it as non-existent website.") {
+            val message = mockk<Message>()
+            coEvery { message.getGuild() } returns mockk {
+                every { id } returns Snowflake(0)
+            }
+
+            val tokens = mutableListOf(TextToken("test https://example.invalid")) // RFC 2606
+            val expectedTokens = mutableListOf(TextToken("test 存在しないWebページへのリンク"))
 
             val processedTokens = UrlReplacer.replace(
                 tokens, Snowflake(0)


### PR DESCRIPTION
タイトルを取得しようとするドメインが存在しない場合と、タイムアウトする場合の例外をキャッチするようにしました。
「存在しないWebページへのリンク」と読み上げます。