### PR TITLE
chore: order aliases by its length, store auditor

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/AliasStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/AliasStore.kt
@@ -46,7 +46,10 @@ object AliasStore : StoreStruct<AliasData>(
                 )
             )
         }
-    )
+    ),
+    auditor = { data ->
+        data.sortedByDescending { it.search.length }.toMutableList()
+    }
 ) {
     fun find(guildId: Snowflake, from: String) =
         data.find { it.guildId == guildId && it.search == from }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/StoreStruct.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/StoreStruct.kt
@@ -24,7 +24,7 @@ data class AnyStore(
 )
 
 /**
- * StoreStructは、配列データを保存するための構造体です。
+ * StoreStruct は、配列データを保存するための構造体です。
  *
  * @param path データを保存するパス
  * @param serializer データの Serializer

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/StoreStruct.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/StoreStruct.kt
@@ -23,6 +23,16 @@ data class AnyStore(
     val list: JsonElement
 )
 
+/**
+ * StoreStructは、配列データを保存するための構造体です。
+ *
+ * @param path データを保存するパス
+ * @param serializer データの Serializer
+ * @param deserializer データの Deserializer; 文字列を受け取り、[TypedStore] を返す関数です
+ * @param version データ構造のバージョン
+ * @param migrators Migrator 関数; Key をバージョンとし, v (Key - 1) のデータを v Key に移行します
+ * @param auditor Auditor 関数; null の場合は何も変更されません。null でない場合、初期化時と [StoreStruct.write] 実行時にデータを監査します
+ */
 open class StoreStruct<T>(
     path: String,
     private val serializer: KSerializer<T>,


### PR DESCRIPTION
エイリアスを長い順にソートしてから適用することにより、例えば "VR", "VRAM" が存在する場合に "VR" が先に適用される問題を修正しました。
また、Store の Audit 機能を実装し、auditor を書けば、初期化時と書き込み時 (`write()`) に data を変更できるようにしました。

エイリアスのソートはこれで実装しています。
ついでに、CacheStore にも、音声ファイルが存在しないデータを削除する処理を実装しました。

close https://github.com/jaoafa/jao-Minecraft-Server/issues/237