### PR TITLE
revert: Noelware/docker-manifest-action 0.4.3に戻す

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,14 +103,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create and push manifest images (latest)
-        uses: Noelware/docker-manifest-action@1.0.0
+        uses: Noelware/docker-manifest-action@0.4.3
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest-amd64,ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest-arm64
           inputs: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:latest
           push: true
 
       - name: Create and push manifest images (version)
-        uses: Noelware/docker-manifest-action@1.0.0
+        uses: Noelware/docker-manifest-action@0.4.3
         with:
           images: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.bump-version.outputs.version }}-amd64,ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.bump-version.outputs.version }}-arm64
           inputs: ghcr.io/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ needs.bump-version.outputs.version }}


### PR DESCRIPTION
1.0.0がリリースされたので適用したのですが、うまく動いてませんでした。
1.0.0に対応させるためにパラメータいじってみましたが、v1で使われるようになったコマンドでは新規イメージが作られないらしく（？）、うまく動きませんでした。ので、戻します。

> ソース・マニフェストは、マニフェストリストや特定プラットフォーム用のディストリビューション・マニフェストとすることができ、**新しいマニフェストリストの作成時には、レジストリに存在していなくてはいけません。**
https://docs.docker.jp/engine/reference/commandline/buildx_imagetools_create.html

なんかわかったら教えてください。
