### PR TITLE
fix: use kord-voice snapshot for new encryption mode

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,6 +12,7 @@ group = "com.jaoafa"
 
 repositories {
     mavenCentral()
+    maven("https://repo.kord.dev/snapshots")
     maven("https://jitpack.io/")
     maven("https://snapshots-repo.kordex.dev")
     maven("https://s01.oss.sonatype.org/content/repositories/snapshots")
@@ -33,7 +34,7 @@ dependencies {
 
     // Discord Related
     implementation("dev.kord:kord-core:0.15.0")
-    implementation("dev.kord:kord-core-voice:0.15.0")
+    implementation("dev.kord:kord-core-voice:new-voice-encryption-modes-SNAPSHOT")
     implementation("dev.kordex:kord-extensions:2.2.1-SNAPSHOT")
     implementation("dev.arbjerg:lavaplayer:2.2.3")
 


### PR DESCRIPTION
特定の Bot アカウントで VC に接続する際、`4016 Unknown encryption mode` エラーが発生する問題に対応しました。

現在 Kord Voice モジュールで実装されている暗号化モードが `XSalsa20Poly1305` のみで、それが去年の終わり頃に非推奨化されたことが原因だと思われます。 [Discord Developer Portal - Transport Encryption Modes](https://discord.com/developers/docs/topics/voice-connections#transport-encryption-modes)

幸運なことにそれに対応するスナップショットが公開されていたので、それを使うようにしました。
Kord リポジトリの PR #990 で対応されているようです。