### PR TITLE
feat: add HTTP timeout configuration for emoji fetching

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/Emoji.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/Emoji.kt
@@ -3,6 +3,7 @@ package com.jaoafa.vcspeaker.tools
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.*
 import io.ktor.client.engine.cio.*
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import kotlinx.coroutines.runBlocking
@@ -20,6 +21,9 @@ object Emoji {
 
         val client = HttpClient(CIO) {
             VCSpeakerUserAgent()
+            install(HttpTimeout) {
+                requestTimeoutMillis = 300_000 // 5 minutes
+            }
         }
 
         val response = client.get("https://unicode.org/Public/emoji/latest/emoji-test.txt")


### PR DESCRIPTION
emoji-test.txt のダウンロード時、以前よりもサーバの応答時間が長くなっているためにタイムアウトする問題がありました。
手元で確認したところ、2分半は少なくともかかりそうなので、5分をタイムアウト値として設定しています。