### PR TITLE
fix: StackOverflowエラーの原因となるapplyFiltersを削除

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/Scheduler.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/Scheduler.kt
@@ -165,15 +165,12 @@ class Scheduler(
     ) {
         val message = current()!!.message
         val guildName = current()!!.guildName
+
         val next = current()!!.next()
 
         // Speech 内に次の Track が存在し、かつ再生が可能な場合、次の Track を再生
         if (endReason.mayStartNext && next != null) {
-            val (nextTrack, nextContext) = next
-
-            link.player.applyFilters {
-                volume = if (nextContext is SoundmojiContext) 20F else 100F
-            }
+            val (nextTrack, _) = next
 
             link.player.playTrack(nextTrack)
             return


### PR DESCRIPTION
Soundemojiが含まれている場合、StackOverflowErrorで再生が止まってしまう現象が出てました。
applyFiltersがあることによる問題なようなので、とりあえず当該処理を削除します。

```
  app-1  | Exception in thread "DefaultDispatcher-worker-18" java.lang.StackOverflowError
  app-1  |      at dev.schlaubi.lavakord.audio.player.PlayerKt.getNode(Player.kt:102)
  app-1  |      at dev.schlaubi.lavakord.audio.player.PlayerKt.getNode(Player.kt:102)
  app-1  |      at dev.schlaubi.lavakord.audio.player.PlayerKt.getNode(Player.kt:102)
  app-1  |      at dev.schlaubi.lavakord.audio.player.PlayerKt.getNode(Player.kt:102)
```