### PR TITLE
fix: TwitterTest が Twitter oEmbed API のドメイン変更(twitter.com→x.com)により失敗する問題を修正

### DIFF
--- a/src/test/kotlin/TwitterTest.kt
+++ b/src/test/kotlin/TwitterTest.kt
@@ -4,6 +4,10 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
+// x.com ドメイン（platform.x.com / pic.x.com / 単独の x.com）にのみマッチし、
+// twitter.com のような無関係な単語には影響しないよう単語境界で区切る
+private val DOMAIN_X_COM = Regex("\\bx\\.com\\b")
+
 class TwitterTest : FunSpec({
     test("If the tweet exists, the tweet information should be returned.") {
         val tweet = Twitter.getTweet("jaoafa", "1685568414084124673")
@@ -16,9 +20,10 @@ class TwitterTest : FunSpec({
 
         tweet.authorName shouldBe "jao Community"
         // Twitter oEmbed API のレスポンスドメインが twitter.com → x.com に変更されたため、
-        // 実測値を twitter.com に正規化してから期待値と比較する
-        tweet.html.replace("x.com", "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"ja\" dir=\"ltr\">この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。<br>利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。<br><br>7年間、本当にありがとうございました。<a href=\"https://twitter.com/hashtag/jaoafa?src=hash&amp;ref_src=twsrc%5Etfw\">#jaoafa</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1685568414084124673?ref_src=twsrc%5Etfw\">July 30, 2023</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
-        tweet.plainText.replace("x.com", "twitter.com") shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。#jaoafa <https://twitter.com/hashtag/jaoafa?src=hash&ref_src=twsrc%5Etfw>"
+        // 実測値のドメイン部分のみ（単語境界で区切られた x.com）を twitter.com に正規化してから期待値と比較する。
+        // "pic.x.com" のようにプロトコルを伴わない表記もあるため、URL プレフィックスではなく \b で範囲を限定する
+        tweet.html.replace(DOMAIN_X_COM, "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"ja\" dir=\"ltr\">この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。<br>利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。<br><br>7年間、本当にありがとうございました。<a href=\"https://twitter.com/hashtag/jaoafa?src=hash&amp;ref_src=twsrc%5Etfw\">#jaoafa</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1685568414084124673?ref_src=twsrc%5Etfw\">July 30, 2023</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
+        tweet.plainText.replace(DOMAIN_X_COM, "twitter.com") shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。#jaoafa <https://twitter.com/hashtag/jaoafa?src=hash&ref_src=twsrc%5Etfw>"
         tweet.readText shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。 ハッシュタグ「jaoafa」"
     }
 
@@ -39,9 +44,10 @@ class TwitterTest : FunSpec({
 
         tweet.authorName shouldBe "jao Community"
         // Twitter oEmbed API のレスポンスドメインが twitter.com → x.com に変更されたため、
-        // 実測値を twitter.com に正規化してから期待値と比較する
-        tweet.html.replace("x.com", "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Do you remember when you joined X? I do! <a href=\"https://twitter.com/hashtag/MyXAnniversary?src=hash&amp;ref_src=twsrc%5Etfw\">#MyXAnniversary</a> <a href=\"https://t.co/JbXvgioO6o\">pic.twitter.com/JbXvgioO6o</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1775559092742021223?ref_src=twsrc%5Etfw\">April 3, 2024</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
-        tweet.plainText.replace("x.com", "twitter.com") shouldBe "Do you remember when you joined X? I do! #MyXAnniversary <https://twitter.com/hashtag/MyXAnniversary?src=hash&ref_src=twsrc%5Etfw> pic.twitter.com/JbXvgioO6o <https://t.co/JbXvgioO6o>"
+        // 実測値のドメイン部分のみ（単語境界で区切られた x.com）を twitter.com に正規化してから期待値と比較する。
+        // "pic.x.com" のようにプロトコルを伴わない表記もあるため、URL プレフィックスではなく \b で範囲を限定する
+        tweet.html.replace(DOMAIN_X_COM, "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Do you remember when you joined X? I do! <a href=\"https://twitter.com/hashtag/MyXAnniversary?src=hash&amp;ref_src=twsrc%5Etfw\">#MyXAnniversary</a> <a href=\"https://t.co/JbXvgioO6o\">pic.twitter.com/JbXvgioO6o</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1775559092742021223?ref_src=twsrc%5Etfw\">April 3, 2024</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
+        tweet.plainText.replace(DOMAIN_X_COM, "twitter.com") shouldBe "Do you remember when you joined X? I do! #MyXAnniversary <https://twitter.com/hashtag/MyXAnniversary?src=hash&ref_src=twsrc%5Etfw> pic.twitter.com/JbXvgioO6o <https://t.co/JbXvgioO6o>"
         tweet.readText shouldBe "Do you remember when you joined X? I do!  ハッシュタグ「MyXAnniversary」"
     }
 })

--- a/src/test/kotlin/TwitterTest.kt
+++ b/src/test/kotlin/TwitterTest.kt
@@ -15,8 +15,10 @@ class TwitterTest : FunSpec({
         tweet.readText.shouldNotBeNull()
 
         tweet.authorName shouldBe "jao Community"
-        tweet.html shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"ja\" dir=\"ltr\">この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。<br>利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。<br><br>7年間、本当にありがとうございました。<a href=\"https://twitter.com/hashtag/jaoafa?src=hash&amp;ref_src=twsrc%5Etfw\">#jaoafa</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1685568414084124673?ref_src=twsrc%5Etfw\">July 30, 2023</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
-        tweet.plainText shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。#jaoafa <https://twitter.com/hashtag/jaoafa?src=hash&ref_src=twsrc%5Etfw>"
+        // Twitter oEmbed API のレスポンスドメインが twitter.com → x.com に変更されたため、
+        // 実測値を twitter.com に正規化してから期待値と比較する
+        tweet.html.replace("x.com", "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"ja\" dir=\"ltr\">この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。<br>利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。<br><br>7年間、本当にありがとうございました。<a href=\"https://twitter.com/hashtag/jaoafa?src=hash&amp;ref_src=twsrc%5Etfw\">#jaoafa</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1685568414084124673?ref_src=twsrc%5Etfw\">July 30, 2023</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
+        tweet.plainText.replace("x.com", "twitter.com") shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。#jaoafa <https://twitter.com/hashtag/jaoafa?src=hash&ref_src=twsrc%5Etfw>"
         tweet.readText shouldBe "この度、jao Minecraft Serverでは2023年08月02日 22時00分をもって、Minecraft サーバのサービス提供を終了させていただくこととなりました。\n利用者のみなさまには、突然のお知らせとなりますことをお詫びいたします。\n\n7年間、本当にありがとうございました。 ハッシュタグ「jaoafa」"
     }
 
@@ -36,8 +38,10 @@ class TwitterTest : FunSpec({
         tweet.readText.shouldNotBeNull()
 
         tweet.authorName shouldBe "jao Community"
-        tweet.html shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Do you remember when you joined X? I do! <a href=\"https://twitter.com/hashtag/MyXAnniversary?src=hash&amp;ref_src=twsrc%5Etfw\">#MyXAnniversary</a> <a href=\"https://t.co/JbXvgioO6o\">pic.twitter.com/JbXvgioO6o</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1775559092742021223?ref_src=twsrc%5Etfw\">April 3, 2024</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
-        tweet.plainText shouldBe "Do you remember when you joined X? I do! #MyXAnniversary <https://twitter.com/hashtag/MyXAnniversary?src=hash&ref_src=twsrc%5Etfw> pic.twitter.com/JbXvgioO6o <https://t.co/JbXvgioO6o>"
+        // Twitter oEmbed API のレスポンスドメインが twitter.com → x.com に変更されたため、
+        // 実測値を twitter.com に正規化してから期待値と比較する
+        tweet.html.replace("x.com", "twitter.com") shouldBe "<blockquote class=\"twitter-tweet\"><p lang=\"en\" dir=\"ltr\">Do you remember when you joined X? I do! <a href=\"https://twitter.com/hashtag/MyXAnniversary?src=hash&amp;ref_src=twsrc%5Etfw\">#MyXAnniversary</a> <a href=\"https://t.co/JbXvgioO6o\">pic.twitter.com/JbXvgioO6o</a></p>&mdash; jao Community (@jaoafa) <a href=\"https://twitter.com/jaoafa/status/1775559092742021223?ref_src=twsrc%5Etfw\">April 3, 2024</a></blockquote>\n<script async src=\"https://platform.twitter.com/widgets.js\" charset=\"utf-8\"></script>\n\n"
+        tweet.plainText.replace("x.com", "twitter.com") shouldBe "Do you remember when you joined X? I do! #MyXAnniversary <https://twitter.com/hashtag/MyXAnniversary?src=hash&ref_src=twsrc%5Etfw> pic.twitter.com/JbXvgioO6o <https://t.co/JbXvgioO6o>"
         tweet.readText shouldBe "Do you remember when you joined X? I do!  ハッシュタグ「MyXAnniversary」"
     }
 })


### PR DESCRIPTION
## 概要

`src/test/kotlin/TwitterTest.kt` の3テスト中2件が、Twitter oEmbed API のレスポンスHTML内のドメインが `twitter.com` から `x.com` に変わったことにより失敗していた問題を修正します。

## 変更内容

- 対象は `src/test/kotlin/TwitterTest.kt` のみ。`Twitter.kt`（本体実装）は変更していません
- `tweet.html` / `tweet.plainText` の実測値に対し、比較前に単純な文字列置換 `.replace("x.com", "twitter.com")` を適用し、既存のハードコードされた期待値（`twitter.com`/`platform.twitter.com`）とそのまま比較する形に修正しました
- なぜこの正規化が必要か・安全かをコメントで明記しました
- `tweet.readText` は `Twitter.kt` 側の正規表現が既に twitter.com/x.com 双方のリンクを除去済みのため変更していません
- 実ネットワーク呼び出しを行う既存のテスト方針自体は維持しています（モック化・CI skip は不採用）

## 検証

- `./gradlew test --tests "TwitterTest"`: 3テストすべて PASSED
- `./gradlew test`（フルスイート）: 136テストすべて PASSED（failures=0, errors=0）
- Deep Review（ローカルdiffモード）: 1件の指摘（コメント欠落、Score 75）を修正済み
- CI（GitHub Actions）: 全チェック PASS

Closes #488