### PR TITLE
fix: 完了済み Deferred への合流でキャッシュヒットの lastUsed 更新が抜ける問題を修正

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/CacheStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/CacheStore.kt
@@ -103,10 +103,8 @@ object CacheStore : StoreStruct<CacheData>(
         val hash = context.hash()
 
         val deferred = pendingMutex.withLock {
-            // 完了済みの Deferred は掃除が非同期のため一時的に残りうる。それに合流すると
-            // read()/onCached() を経ずに完了値だけを受け取り、キャッシュヒット時の lastUsed 更新が
-            // 抜けてしまう。完了済みエントリは不在扱いにして新規 fetch を起こし、真に fetch 中
-            // (未完了) の呼び出しだけを合流させる。
+            // 完了済み Deferred(掃除が非同期のため一時的に残る)に合流すると、
+            // read()/onCached() を経ずに lastUsed 更新が抜けるため、未完了のものだけ合流させる。
             val inFlight = pendingByHash[hash]?.takeIf { !it.isCompleted }
 
             inFlight ?: fetchScope.async {
@@ -120,9 +118,8 @@ object CacheStore : StoreStruct<CacheData>(
                 }
             }.also { newDeferred ->
                 pendingByHash[hash] = newDeferred
-                // 呼び出し元のキャンセルとは無関係に、fetch 自体の完了時に一度だけ掃除する。
-                // 呼び出し元の finally で remove すると、待機側だけがキャンセルされた場合に
-                // fetch が完了していないのにエントリが消え、次の呼び出しが二重に fetch を開始してしまう。
+                // 呼び出し元の finally で remove すると、待機側だけキャンセルされた場合に
+                // fetch 未完了のままエントリが消え二重 fetch を招くため、fetch 自体の完了時に掃除する。
                 newDeferred.invokeOnCompletion {
                     fetchScope.launch {
                         pendingMutex.withLock {

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/CacheStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/CacheStore.kt
@@ -103,25 +103,30 @@ object CacheStore : StoreStruct<CacheData>(
         val hash = context.hash()
 
         val deferred = pendingMutex.withLock {
-            pendingByHash.getOrPut(hash) {
-                fetchScope.async {
-                    val file = read(context)
-                    if (file != null) {
-                        onCached()
-                        file
-                    } else {
-                        cacheFile(context).writeText("")
-                        create(context, onNoCache())
-                    }
-                }.also { newDeferred ->
-                    // 呼び出し元のキャンセルとは無関係に、fetch 自体の完了時に一度だけ掃除する。
-                    // 呼び出し元の finally で remove すると、待機側だけがキャンセルされた場合に
-                    // fetch が完了していないのにエントリが消え、次の呼び出しが二重に fetch を開始してしまう。
-                    newDeferred.invokeOnCompletion {
-                        fetchScope.launch {
-                            pendingMutex.withLock {
-                                if (pendingByHash[hash] === newDeferred) pendingByHash.remove(hash)
-                            }
+            // 完了済みの Deferred は掃除が非同期のため一時的に残りうる。それに合流すると
+            // read()/onCached() を経ずに完了値だけを受け取り、キャッシュヒット時の lastUsed 更新が
+            // 抜けてしまう。完了済みエントリは不在扱いにして新規 fetch を起こし、真に fetch 中
+            // (未完了) の呼び出しだけを合流させる。
+            val inFlight = pendingByHash[hash]?.takeIf { !it.isCompleted }
+
+            inFlight ?: fetchScope.async {
+                val file = read(context)
+                if (file != null) {
+                    onCached()
+                    file
+                } else {
+                    cacheFile(context).writeText("")
+                    create(context, onNoCache())
+                }
+            }.also { newDeferred ->
+                pendingByHash[hash] = newDeferred
+                // 呼び出し元のキャンセルとは無関係に、fetch 自体の完了時に一度だけ掃除する。
+                // 呼び出し元の finally で remove すると、待機側だけがキャンセルされた場合に
+                // fetch が完了していないのにエントリが消え、次の呼び出しが二重に fetch を開始してしまう。
+                newDeferred.invokeOnCompletion {
+                    fetchScope.launch {
+                        pendingMutex.withLock {
+                            if (pendingByHash[hash] === newDeferred) pendingByHash.remove(hash)
                         }
                     }
                 }


### PR DESCRIPTION
## 概要

音声合成のキャッシュファイルを扱う `CacheStore.readOrCreate` にあったバグを修正します。
キャッシュがヒットしたのに「今使った」という記録(`lastUsed`)が更新されず、まだ使っているキャッシュが古いものとして早めに消されてしまうことがありました。

## 何が起きていたか

`readOrCreate` は、同じキャッシュへの問い合わせが同時に来たときに処理をまとめて 1 回で済ませる仕組み(coalescing)を持っています。

このとき、処理が終わったあとの後始末(`pendingByHash` からの削除)がわずかに遅れることがあり、そのタイミングで次の問い合わせが来ると「もう終わった処理」に相乗りしてしまっていました。相乗りすると、本来通るはずの `onCached()` の呼び出しや `lastUsed` の更新処理を素通りしてしまい、結果を受け取るだけになります。

キャッシュの整理(`initiateAuditJob`)は `lastUsed` が新しい順に上位 100 件だけを残す仕組みのため、`lastUsed` が更新されないキャッシュはまだ使っているのに早く削除されてしまう、というのが実際に起きていた不具合です。頻度は低いものの、本番でも起こりうる問題でした。

### 図解(修正前)

```mermaid
sequenceDiagram
    participant A as 呼び出し元 A
    participant Store as pendingByHash
    participant B as 呼び出し元 B

    A->>Store: 問い合わせ(処理なし→新規Deferred登録)
    Store-->>A: read() → onCached() → lastUsed更新 → 完了
    Note over Store: 完了後の削除は非同期のため<br/>一瞬 Deferred が残ったまま
    B->>Store: 同じキャッシュに問い合わせ
    Store-->>B: 残っていた「完了済み」Deferredに相乗り
    Note over B: read()/onCached()を通らず<br/>結果だけ受け取る → lastUsed更新されない
    Store->>Store: 遅れて削除処理が走る
```

### 図解(修正後)

```mermaid
sequenceDiagram
    participant A as 呼び出し元 A
    participant Store as pendingByHash
    participant B as 呼び出し元 B

    A->>Store: 問い合わせ(処理なし→新規Deferred登録)
    Store-->>A: read() → onCached() → lastUsed更新 → 完了
    Note over Store: 完了後の削除は非同期のため<br/>一瞬 Deferred が残ったまま
    B->>Store: 同じキャッシュに問い合わせ
    Store->>Store: 残っている Deferred が完了済みか確認
    Note over Store: 完了済みなら「不在」扱いにする
    Store-->>B: 新規Deferredでread()からやり直し
    B->>B: onCached() → lastUsed更新 → 完了
    Store->>Store: 遅れて削除処理が走る(A分・B分とも)
```

## 直したこと

相乗り先を選ぶときに「まだ終わっていない処理」だけを対象にするようにしました。すでに終わっている処理には相乗りせず、新しく `read()` からやり直すことで、`onCached()` と `lastUsed` の更新が必ず通るようにしています。

- 本当に処理中の呼び出し同士がまとめられる挙動はそのまま維持しています。
- 後始末のガード処理も変更していないため、別の不具合が新たに入り込むことはありません。

## テスト

`stores.CacheStoreTest`(3件)がローカルで通ることを確認しました。以前は不安定だった `A cache hit should update lastUsed to a newer timestamp.` を含め、`--rerun-tasks` で 5 回連続成功しています。

## 関連

Renovate PR #473 のブランチとは無関係の独立した修正です(#473 の CI が不安定だった原因を調べていて見つかりました)。
