### PR TITLE
feat: ゲームメンション(<@$GAME_ID>)をゲーム名で読み上げる

### DIFF
--- a/src/main/kotlin/com/jaoafa/vcspeaker/VCSpeaker.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/VCSpeaker.kt
@@ -49,6 +49,7 @@ object VCSpeaker {
         val readableBot = storeFolder + File("readablebots.json")
         val readableChannel = storeFolder + File("readablechannels.json")
         val visionApiCounter = storeFolder + File("vision-api-counter.json")
+        val games = storeFolder + File("games.json")
 
         val visionApiCache = storeFolder + File("vision-api") + File("cache")
     }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordDetectableApplication.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordDetectableApplication.kt
@@ -1,0 +1,15 @@
+package com.jaoafa.vcspeaker.models.response.discord
+
+import kotlinx.serialization.Serializable
+
+/**
+ * `applications/detectable` レスポンス配列の要素。
+ * 実際のレスポンスは他に多数のフィールド(aliases 等)を持つが、
+ * このアプリケーションでは id / name のみを使用するため、
+ * ContentNegotiation の ignoreUnknownKeys = true で残りを無視する。
+ */
+@Serializable
+internal data class DiscordDetectableApplication(
+    val id: String,
+    val name: String
+)

--- a/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordDetectableApplication.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordDetectableApplication.kt
@@ -4,9 +4,7 @@ import kotlinx.serialization.Serializable
 
 /**
  * `applications/detectable` レスポンス配列の要素。
- * 実際のレスポンスは他に多数のフィールド(aliases 等)を持つが、
- * このアプリケーションでは id / name のみを使用するため、
- * ContentNegotiation の ignoreUnknownKeys = true で残りを無視する。
+ * 他のフィールドは ignoreUnknownKeys = true で無視する。
  */
 @Serializable
 internal data class DiscordDetectableApplication(

--- a/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordRateLimitResponse.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/models/response/discord/DiscordRateLimitResponse.kt
@@ -1,0 +1,15 @@
+package com.jaoafa.vcspeaker.models.response.discord
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * HTTP 429 (Too Many Requests) レスポンスボディの構造。
+ * Discord API は `Retry-After` ヘッダーとともに JSON ボディに `retry_after` フィールドを返す場合がある。
+ * 両者が存在する場合、ヘッダーを優先するが、ヘッダーが無い場合のフォールバックとしてボディを参照する。
+ */
+@Serializable
+internal data class DiscordRateLimitResponse(
+    @SerialName("retry_after")
+    val retryAfter: Double? = null
+)

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/GameStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/GameStore.kt
@@ -1,0 +1,34 @@
+package com.jaoafa.vcspeaker.stores
+
+import com.jaoafa.vcspeaker.VCSpeaker
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class GameData(
+    val id: Long,
+    val name: String,
+    val updatedAt: Long
+)
+
+/**
+ * `applications/detectable` から取得したゲーム一覧のキャッシュ。
+ * `updatedAt` は game ID ごとの値ではなく、カタログ全体を最後に再取得した時刻。
+ * [replaceAll] のたびに全件が同じ `updatedAt` で上書きされる。
+ */
+object GameStore : StoreStruct<GameData>(
+    VCSpeaker.Files.games.path,
+    GameData.serializer(),
+    { Json.decodeFromString(this) },
+
+    version = 1
+) {
+    suspend fun find(id: Long): GameData? = withData { data.find { it.id == id } }
+
+    suspend fun lastFetchedAt(): Long? = withData { data.maxOfOrNull { it.updatedAt } }
+
+    suspend fun replaceAll(games: Map<Long, String>, updatedAt: Long): Unit = withData {
+        data = games.map { (id, name) -> GameData(id, name, updatedAt) }.toMutableList()
+        writeLocked()
+    }
+}

--- a/src/main/kotlin/com/jaoafa/vcspeaker/stores/GameStore.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/stores/GameStore.kt
@@ -14,7 +14,8 @@ data class GameData(
 /**
  * `applications/detectable` から取得したゲーム一覧のキャッシュ。
  * `updatedAt` は game ID ごとの値ではなく、カタログ全体を最後に再取得した時刻。
- * [replaceAll] のたびに全件が同じ `updatedAt` で上書きされる。
+ * Discord のゲーム ID は正の値のみのため、[LAST_FETCHED_AT_ID] を負の値の
+ * sentinel エントリとして [data] に混在させ、空カタログでも最終取得時刻を保持する。
  */
 object GameStore : StoreStruct<GameData>(
     VCSpeaker.Files.games.path,
@@ -23,12 +24,19 @@ object GameStore : StoreStruct<GameData>(
 
     version = 1
 ) {
+    private const val LAST_FETCHED_AT_ID = -1L
+
     suspend fun find(id: Long): GameData? = withData { data.find { it.id == id } }
 
-    suspend fun lastFetchedAt(): Long? = withData { data.maxOfOrNull { it.updatedAt } }
+    suspend fun findAll(ids: Set<Long>): Map<Long, String> = withData {
+        data.filter { it.id in ids }.associate { it.id to it.name }
+    }
+
+    suspend fun lastFetchedAt(): Long? = withData { data.find { it.id == LAST_FETCHED_AT_ID }?.updatedAt }
 
     suspend fun replaceAll(games: Map<Long, String>, updatedAt: Long): Unit = withData {
-        data = games.map { (id, name) -> GameData(id, name, updatedAt) }.toMutableList()
+        data = (games.map { (id, name) -> GameData(id, name, updatedAt) } + GameData(LAST_FETCHED_AT_ID, "", updatedAt))
+            .toMutableList()
         writeLocked()
     }
 }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
@@ -13,9 +13,8 @@ import io.ktor.client.request.get
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.serialization.SerializationException
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
-import java.io.IOException
 
 /**
  * Discord の非公開 API `applications/detectable` との通信を担当する。
@@ -59,7 +58,6 @@ object DiscordGameApi {
             val response = client.get(URL)
 
             if (response.status == HttpStatusCode.TooManyRequests) {
-                // Try Retry-After header first; if missing, try retry_after in response body
                 val retryAfterSeconds = response.headers[HttpHeaders.RetryAfter]?.toDoubleOrNull()
                     ?: try {
                         response.body<DiscordRateLimitResponse>().retryAfter
@@ -78,11 +76,10 @@ object DiscordGameApi {
             response.body<List<DiscordDetectableApplication>>()
                 .mapNotNull { app -> app.id.toLongOrNull()?.let { it to app.name } }
                 .toMap()
-        } catch (e: IOException) {
-            logger.warn(e) { "I/O error while fetching applications/detectable." }
-            null
-        } catch (e: SerializationException) {
-            logger.warn(e) { "Failed to decode applications/detectable response." }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.warn(e) { "Failed to fetch applications/detectable." }
             null
         }
     }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
@@ -1,0 +1,86 @@
+package com.jaoafa.vcspeaker.tools.discord
+
+import com.jaoafa.vcspeaker.models.response.discord.DiscordDetectableApplication
+import com.jaoafa.vcspeaker.tools.VCSpeakerUserAgent
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.IOException
+
+/**
+ * Discord の非公開 API `applications/detectable` との通信を担当する。
+ * このエンドポイントは認証不要であることを実際の Bot token で確認済みのため、
+ * Authorization ヘッダーは付与しない。
+ */
+object DiscordGameApi {
+    private val logger = KotlinLogging.logger {}
+
+    private const val URL = "https://discord.com/api/v10/applications/detectable"
+
+    private val client = HttpClient(CIO) {
+        VCSpeakerUserAgent()
+
+        install(ContentNegotiation) {
+            json(Json {
+                ignoreUnknownKeys = true
+            })
+        }
+
+        install(HttpTimeout) {
+            requestTimeoutMillis = 30000
+        }
+    }
+
+    // 429 応答時のプロセスローカル cooldown。プロセス内メモリのみで永続化せず、再起動でリセットされる。
+    private var cooldownUntil: Long? = null
+
+    /**
+     * ゲーム一覧を全件取得する。失敗時(HTTP 429/5xx/401/403、タイムアウト、
+     * 接続失敗、JSON デコード失敗のいずれか)は例外を伝播させず null を返す。
+     */
+    suspend fun getDetectableGames(): Map<Long, String>? {
+        val cooldown = cooldownUntil
+        if (cooldown != null && System.currentTimeMillis() < cooldown) {
+            logger.info { "Skipping applications/detectable fetch due to active cooldown." }
+            return null
+        }
+
+        return try {
+            val response = client.get(URL)
+
+            if (response.status == HttpStatusCode.TooManyRequests) {
+                applyCooldown(response.headers[HttpHeaders.RetryAfter])
+                return null
+            }
+
+            if (response.status.value !in 200..299) {
+                logger.warn { "Failed to fetch applications/detectable. status=${response.status}" }
+                return null
+            }
+
+            response.body<List<DiscordDetectableApplication>>()
+                .mapNotNull { app -> app.id.toLongOrNull()?.let { it to app.name } }
+                .toMap()
+        } catch (e: IOException) {
+            logger.warn(e) { "I/O error while fetching applications/detectable." }
+            null
+        } catch (e: SerializationException) {
+            logger.warn(e) { "Failed to decode applications/detectable response." }
+            null
+        }
+    }
+
+    private fun applyCooldown(retryAfterHeader: String?) {
+        val retryAfterSeconds = retryAfterHeader?.toDoubleOrNull() ?: return
+        cooldownUntil = System.currentTimeMillis() + (retryAfterSeconds * 1000).toLong()
+    }
+}

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
@@ -1,6 +1,7 @@
 package com.jaoafa.vcspeaker.tools.discord
 
 import com.jaoafa.vcspeaker.models.response.discord.DiscordDetectableApplication
+import com.jaoafa.vcspeaker.models.response.discord.DiscordRateLimitResponse
 import com.jaoafa.vcspeaker.tools.VCSpeakerUserAgent
 import io.github.oshai.kotlinlogging.KotlinLogging
 import io.ktor.client.HttpClient
@@ -58,7 +59,14 @@ object DiscordGameApi {
             val response = client.get(URL)
 
             if (response.status == HttpStatusCode.TooManyRequests) {
-                applyCooldown(response.headers[HttpHeaders.RetryAfter])
+                // Try Retry-After header first; if missing, try retry_after in response body
+                val retryAfterSeconds = response.headers[HttpHeaders.RetryAfter]?.toDoubleOrNull()
+                    ?: try {
+                        response.body<DiscordRateLimitResponse>().retryAfter
+                    } catch (e: Exception) {
+                        null
+                    }
+                applyCooldown(retryAfterSeconds)
                 return null
             }
 
@@ -79,8 +87,8 @@ object DiscordGameApi {
         }
     }
 
-    private fun applyCooldown(retryAfterHeader: String?) {
-        val retryAfterSeconds = retryAfterHeader?.toDoubleOrNull() ?: return
-        cooldownUntil = System.currentTimeMillis() + (retryAfterSeconds * 1000).toLong()
+    private fun applyCooldown(retryAfterSeconds: Double?) {
+        val seconds = retryAfterSeconds ?: return
+        cooldownUntil = System.currentTimeMillis() + (seconds * 1000).toLong()
     }
 }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
@@ -78,6 +78,8 @@ object DiscordGameApi {
                 .mapNotNull { app -> app.id.toLongOrNull()?.let { it to app.name } }
                 .toMap()
         } catch (e: CancellationException) {
+            // CancellationException は Exception のサブクラスのため、下の catch (e: Exception) に
+            // 素通りさせるとコルーチンのキャンセル伝播が壊れる。ここで明示的に rethrow する。
             throw e
         } catch (e: Exception) {
             logger.warn(e) { "Failed to fetch applications/detectable." }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/DiscordGameApi.kt
@@ -18,8 +18,7 @@ import kotlinx.serialization.json.Json
 
 /**
  * Discord の非公開 API `applications/detectable` との通信を担当する。
- * このエンドポイントは認証不要であることを実際の Bot token で確認済みのため、
- * Authorization ヘッダーは付与しない。
+ * このエンドポイントは認証不要のため、Authorization ヘッダーは付与しない。
  */
 object DiscordGameApi {
     private val logger = KotlinLogging.logger {}
@@ -44,8 +43,8 @@ object DiscordGameApi {
     private var cooldownUntil: Long? = null
 
     /**
-     * ゲーム一覧を全件取得する。失敗時(HTTP 429/5xx/401/403、タイムアウト、
-     * 接続失敗、JSON デコード失敗のいずれか)は例外を伝播させず null を返す。
+     * ゲーム一覧を全件取得する。取得に失敗した場合は例外を伝播させず null を返し、
+     * TTS 全体を停止させない。
      */
     suspend fun getDetectableGames(): Map<Long, String>? {
         val cooldown = cooldownUntil
@@ -62,8 +61,10 @@ object DiscordGameApi {
                     ?: try {
                         response.body<DiscordRateLimitResponse>().retryAfter
                     } catch (e: Exception) {
+                        logger.warn(e) { "Failed to decode rate limit response body for applications/detectable." }
                         null
                     }
+                logger.warn { "Rate limited on applications/detectable. retryAfterSeconds=$retryAfterSeconds" }
                 applyCooldown(retryAfterSeconds)
                 return null
             }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit
  * カタログ全体の最終取得時刻(GameStore.lastFetchedAt())を基準に行う。
  */
 object GameResolver {
-    private val ttlMillis = TimeUnit.DAYS.toMillis(90)
+    private val ttlMillis = TimeUnit.DAYS.toMillis(7)
 
     // カタログの再取得を直列化する。キーは単一(カタログ全体で 1 つ)のため Mutex のみで足りる。
     private val refreshMutex = Mutex()

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
@@ -1,0 +1,41 @@
+package com.jaoafa.vcspeaker.tools.discord
+
+import com.jaoafa.vcspeaker.stores.GameStore
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.TimeUnit
+
+/**
+ * game ID からゲーム名を解決する。キャッシュ(GameStore)の fresh/stale 判定は
+ * game ID 単位ではなく、カタログ全体を最後に取得した時刻(GameStore.lastFetchedAt())
+ * を基準に行う。
+ */
+object GameResolver {
+    private val ttlMillis = TimeUnit.DAYS.toMillis(90)
+
+    // カタログの再取得を直列化する。キーは単一(カタログ全体で 1 つ)のため Mutex のみで足りる。
+    private val refreshMutex = Mutex()
+
+    suspend fun resolve(gameIds: List<Long>): Map<Long, String?> {
+        refreshCatalogIfStale()
+
+        return gameIds.associateWith { id -> GameStore.find(id)?.name }
+    }
+
+    private suspend fun refreshCatalogIfStale() {
+        if (!isStale()) return
+
+        refreshMutex.withLock {
+            // ロック取得までの間に他の呼び出しが再取得済みの可能性があるため再チェックする
+            if (!isStale()) return@withLock
+
+            val games = DiscordGameApi.getDetectableGames() ?: return@withLock
+            GameStore.replaceAll(games, System.currentTimeMillis())
+        }
+    }
+
+    private suspend fun isStale(): Boolean {
+        val lastFetchedAt = GameStore.lastFetchedAt() ?: return true
+        return System.currentTimeMillis() - lastFetchedAt > ttlMillis
+    }
+}

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
@@ -16,6 +16,11 @@ object GameResolver {
     // カタログの再取得を直列化する。キーは単一(カタログ全体で 1 つ)のため Mutex のみで足りる。
     private val refreshMutex = Mutex()
 
+    // 取得失敗時のプロセスローカル cooldown。プロセス内メモリのみで永続化せず、再起動でリセットされる。
+    // 固定値であり仕様値ではない。再取得の連続失敗によるリトライストームを避けるためのもの。
+    private var refreshFailedUntil: Long? = null
+    private val failureCooldownMillis = TimeUnit.MINUTES.toMillis(5)
+
     suspend fun resolve(gameIds: List<Long>): Map<Long, String?> {
         refreshCatalogIfStale()
 
@@ -29,7 +34,14 @@ object GameResolver {
             // ロック取得までの間に他の呼び出しが再取得済みの可能性があるため再チェックする
             if (!isStale()) return@withLock
 
-            val games = DiscordGameApi.getDetectableGames() ?: return@withLock
+            val failedUntil = refreshFailedUntil
+            if (failedUntil != null && System.currentTimeMillis() < failedUntil) return@withLock
+
+            val games = DiscordGameApi.getDetectableGames()
+            if (games == null) {
+                refreshFailedUntil = System.currentTimeMillis() + failureCooldownMillis
+                return@withLock
+            }
             GameStore.replaceAll(games, System.currentTimeMillis())
         }
     }

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tools/discord/GameResolver.kt
@@ -6,9 +6,8 @@ import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.TimeUnit
 
 /**
- * game ID からゲーム名を解決する。キャッシュ(GameStore)の fresh/stale 判定は
- * game ID 単位ではなく、カタログ全体を最後に取得した時刻(GameStore.lastFetchedAt())
- * を基準に行う。
+ * game ID からゲーム名を解決する。fresh/stale 判定は game ID 単位ではなく、
+ * カタログ全体の最終取得時刻(GameStore.lastFetchedAt())を基準に行う。
  */
 object GameResolver {
     private val ttlMillis = TimeUnit.DAYS.toMillis(90)
@@ -24,7 +23,8 @@ object GameResolver {
     suspend fun resolve(gameIds: List<Long>): Map<Long, String?> {
         refreshCatalogIfStale()
 
-        return gameIds.associateWith { id -> GameStore.find(id)?.name }
+        val names = GameStore.findAll(gameIds.toSet())
+        return gameIds.associateWith { id -> names[id] }
     }
 
     private suspend fun refreshCatalogIfStale() {

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
@@ -1,0 +1,52 @@
+package com.jaoafa.vcspeaker.tts.replacers
+
+import com.jaoafa.vcspeaker.tools.discord.GameResolver
+import com.jaoafa.vcspeaker.tts.TextToken
+import dev.kord.common.entity.Snowflake
+
+/**
+ * ゲームメンションを置換するクラス
+ */
+object GameMentionReplacer : BaseReplacer {
+    override val priority = ReplacerPriority.Normal
+
+    private val regex = Regex("<@\\$(\\d+)>")
+
+    override suspend fun replace(tokens: MutableList<TextToken>, guildId: Snowflake): MutableList<TextToken> {
+        val ids = tokens.flatMap { token ->
+            regex.findAll(token.text).map { it.groupValues[1].toLong() }
+        }.distinct()
+
+        if (ids.isEmpty()) return tokens
+
+        val resolved = GameResolver.resolve(ids)
+
+        return buildList {
+            for (token in tokens) {
+                val text = token.text
+
+                if (token.replaced() || !text.partialMatch(regex)) {
+                    add(token)
+                    continue
+                }
+
+                val matches = regex.findAll(text).toList()
+                val splitTexts = text.split(regex)
+
+                val additions = splitTexts.mixin { index ->
+                    val match = matches[index]
+                    val id = match.groupValues[1].toLong()
+                    val name = resolved[id]
+
+                    if (name != null) {
+                        TextToken(name, "Game `$id` →「$name」")
+                    } else {
+                        TextToken("ゲーム", "Game `$id` → 不明")
+                    }
+                }
+
+                addAll(additions.filter { it.text.isNotEmpty() })
+            }
+        }.toMutableList()
+    }
+}

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
@@ -13,11 +13,11 @@ object GameMentionReplacer : BaseReplacer {
     private val regex = Regex("<@\\$(\\d+)>")
 
     override suspend fun replace(tokens: MutableList<TextToken>, guildId: Snowflake): MutableList<TextToken> {
-        val ids = tokens.flatMap { token ->
-            regex.findAll(token.text).map { it.groupValues[1].toLong() }
-        }.distinct()
+        if (tokens.none { !it.replaced() && it.text.partialMatch(regex) }) return tokens
 
-        if (ids.isEmpty()) return tokens
+        val ids = tokens.flatMap { token ->
+            regex.findAll(token.text).mapNotNull { it.groupValues[1].toLongOrNull() }
+        }.distinct()
 
         val resolved = GameResolver.resolve(ids)
 
@@ -35,13 +35,14 @@ object GameMentionReplacer : BaseReplacer {
 
                 val additions = splitTexts.mixin { index ->
                     val match = matches[index]
-                    val id = match.groupValues[1].toLong()
-                    val name = resolved[id]
+                    val rawId = match.groupValues[1]
+                    val id = rawId.toLongOrNull()
+                    val name = id?.let { resolved[it] }
 
                     if (name != null) {
-                        TextToken(name, "Game `$id` →「$name」")
+                        TextToken(name, "Game `$rawId` →「$name」")
                     } else {
-                        TextToken("ゲーム", "Game `$id` → 不明")
+                        TextToken("ゲーム", "Game `$rawId` → 不明")
                     }
                 }
 

--- a/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
+++ b/src/main/kotlin/com/jaoafa/vcspeaker/tts/replacers/GameMentionReplacer.kt
@@ -31,7 +31,14 @@ object GameMentionReplacer : BaseReplacer {
                 }
 
                 val matches = regex.findAll(text).toList()
-                val splitTexts = text.split(regex)
+                val splitTexts = buildList {
+                    var lastIndex = 0
+                    for (match in matches) {
+                        add(text.substring(lastIndex, match.range.first))
+                        lastIndex = match.range.last + 1
+                    }
+                    add(text.substring(lastIndex))
+                }
 
                 val additions = splitTexts.mixin { index ->
                     val match = matches[index]

--- a/src/test/kotlin/replacers/GameMentionReplacerTest.kt
+++ b/src/test/kotlin/replacers/GameMentionReplacerTest.kt
@@ -1,0 +1,85 @@
+package replacers
+
+import com.jaoafa.vcspeaker.tools.discord.GameResolver
+import com.jaoafa.vcspeaker.tts.TextToken
+import com.jaoafa.vcspeaker.tts.replacers.GameMentionReplacer
+import dev.kord.common.entity.Snowflake
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockkObject
+
+class GameMentionReplacerTest : FunSpec({
+    afterTest {
+        clearAllMocks()
+    }
+
+    test("If a known game mention is found, it should be replaced with the game name.") {
+        mockkObject(GameResolver)
+        coEvery { GameResolver.resolve(listOf(123456789L)) } returns mapOf(123456789L to "Test Game")
+
+        val tokens = mutableListOf(TextToken("Playing <@$123456789> now!"))
+        val expectedTokens = mutableListOf(
+            TextToken("Playing "),
+            TextToken("Test Game", "Game `123456789` →「Test Game」"),
+            TextToken(" now!")
+        )
+
+        val processedTokens = GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        processedTokens shouldBe expectedTokens
+    }
+
+    test("If an unresolved game mention is found, it should be replaced with 「ゲーム」.") {
+        mockkObject(GameResolver)
+        coEvery { GameResolver.resolve(listOf(999L)) } returns mapOf(999L to null)
+
+        val tokens = mutableListOf(TextToken("Playing <@$999> now!"))
+        val expectedTokens = mutableListOf(
+            TextToken("Playing "),
+            TextToken("ゲーム", "Game `999` → 不明"),
+            TextToken(" now!")
+        )
+
+        val processedTokens = GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        processedTokens shouldBe expectedTokens
+    }
+
+    test("If no game mention is found, the text should not be changed.") {
+        val tokens = mutableListOf(TextToken("Hello, world!"))
+
+        val processedTokens = GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        processedTokens shouldBe tokens
+    }
+
+    test("If multiple game mentions are found, all should be replaced.") {
+        mockkObject(GameResolver)
+        coEvery { GameResolver.resolve(listOf(1L, 2L)) } returns mapOf(1L to "Game One", 2L to "Game Two")
+
+        val tokens = mutableListOf(TextToken("<@$1> and <@$2>"))
+        val expectedTokens = mutableListOf(
+            TextToken("Game One", "Game `1` →「Game One」"),
+            TextToken(" and "),
+            TextToken("Game Two", "Game `2` →「Game Two」")
+        )
+
+        val processedTokens = GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        processedTokens shouldBe expectedTokens
+    }
+
+    test("If the same game id appears multiple times, GameResolver should be queried once with distinct ids.") {
+        mockkObject(GameResolver)
+        coEvery { GameResolver.resolve(listOf(1L)) } returns mapOf(1L to "Game One")
+
+        val tokens = mutableListOf(TextToken("<@$1> and <@$1> again"))
+
+        GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        coVerify(exactly = 1) { GameResolver.resolve(listOf(1L)) }
+    }
+})

--- a/src/test/kotlin/replacers/GameMentionReplacerTest.kt
+++ b/src/test/kotlin/replacers/GameMentionReplacerTest.kt
@@ -82,4 +82,20 @@ class GameMentionReplacerTest : FunSpec({
 
         coVerify(exactly = 1) { GameResolver.resolve(listOf(1L)) }
     }
+
+    test("If a game id exceeds Long.MAX_VALUE, it should be replaced with 「ゲーム」 without throwing.") {
+        mockkObject(GameResolver)
+        coEvery { GameResolver.resolve(emptyList()) } returns emptyMap()
+
+        val tokens = mutableListOf(TextToken("Playing <@$99999999999999999999> now!"))
+        val expectedTokens = mutableListOf(
+            TextToken("Playing "),
+            TextToken("ゲーム", "Game `99999999999999999999` → 不明"),
+            TextToken(" now!")
+        )
+
+        val processedTokens = GameMentionReplacer.replace(tokens, Snowflake(0))
+
+        processedTokens shouldBe expectedTokens
+    }
 })

--- a/src/test/kotlin/stores/GameStoreTest.kt
+++ b/src/test/kotlin/stores/GameStoreTest.kt
@@ -1,0 +1,71 @@
+package stores
+
+import com.jaoafa.vcspeaker.VCSpeaker
+import com.jaoafa.vcspeaker.stores.GameStore
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import java.io.File
+
+class GameStoreTest : FunSpec({
+    beforeSpec {
+        mockkObject(VCSpeaker)
+        every { VCSpeaker.storeFolder } returns File(System.getProperty("java.io.tmpdir") + File.separator + "vcspeaker-test-${System.currentTimeMillis()}")
+        VCSpeaker.storeFolder.mkdirs()
+
+        val gameFile = File(VCSpeaker.storeFolder, "games.json")
+        gameFile.writeText("""{"version":1,"list":[]}""")
+    }
+
+    afterTest {
+        GameStore.data.clear()
+    }
+
+    // --- replaceAll / find ---
+
+    context("replaceAll") {
+        test("If replaceAll is called, find should return the stored name for each id.") {
+            GameStore.replaceAll(mapOf(1L to "Game One", 2L to "Game Two"), 1000L)
+
+            GameStore.find(1L)?.name shouldBe "Game One"
+            GameStore.find(2L)?.name shouldBe "Game Two"
+        }
+
+        test("If replaceAll is called, an id not in the map should not be found.") {
+            GameStore.replaceAll(mapOf(1L to "Game One"), 1000L)
+
+            GameStore.find(999L).shouldBeNull()
+        }
+
+        test("If replaceAll is called again with a different map, previous entries not in the new map should be removed.") {
+            GameStore.replaceAll(mapOf(1L to "Game One"), 1000L)
+            GameStore.replaceAll(mapOf(2L to "Game Two"), 2000L)
+
+            GameStore.find(1L).shouldBeNull()
+            GameStore.find(2L)?.name shouldBe "Game Two"
+        }
+
+        test("If replaceAll is called, every entry should be stamped with the given updatedAt.") {
+            GameStore.replaceAll(mapOf(1L to "Game One", 2L to "Game Two"), 1234L)
+
+            GameStore.find(1L)?.updatedAt shouldBe 1234L
+            GameStore.find(2L)?.updatedAt shouldBe 1234L
+        }
+    }
+
+    // --- lastFetchedAt ---
+
+    context("lastFetchedAt") {
+        test("If no entry is stored, lastFetchedAt should return null.") {
+            GameStore.lastFetchedAt().shouldBeNull()
+        }
+
+        test("If entries are stored, lastFetchedAt should return the max updatedAt.") {
+            GameStore.replaceAll(mapOf(1L to "Game One", 2L to "Game Two"), 5000L)
+
+            GameStore.lastFetchedAt() shouldBe 5000L
+        }
+    }
+})

--- a/src/test/kotlin/stores/GameStoreTest.kt
+++ b/src/test/kotlin/stores/GameStoreTest.kt
@@ -55,6 +55,16 @@ class GameStoreTest : FunSpec({
         }
     }
 
+    // --- findAll ---
+
+    context("findAll") {
+        test("If findAll is called, it should return only the requested ids that exist.") {
+            GameStore.replaceAll(mapOf(1L to "Game One", 2L to "Game Two"), 1000L)
+
+            GameStore.findAll(setOf(1L, 999L)) shouldBe mapOf(1L to "Game One")
+        }
+    }
+
     // --- lastFetchedAt ---
 
     context("lastFetchedAt") {
@@ -62,10 +72,16 @@ class GameStoreTest : FunSpec({
             GameStore.lastFetchedAt().shouldBeNull()
         }
 
-        test("If entries are stored, lastFetchedAt should return the max updatedAt.") {
+        test("If entries are stored, lastFetchedAt should return the given updatedAt.") {
             GameStore.replaceAll(mapOf(1L to "Game One", 2L to "Game Two"), 5000L)
 
             GameStore.lastFetchedAt() shouldBe 5000L
+        }
+
+        test("If replaceAll is called with an empty map, lastFetchedAt should still return the given updatedAt.") {
+            GameStore.replaceAll(emptyMap(), 6000L)
+
+            GameStore.lastFetchedAt() shouldBe 6000L
         }
     }
 })

--- a/src/test/kotlin/tools/discord/GameResolverTest.kt
+++ b/src/test/kotlin/tools/discord/GameResolverTest.kt
@@ -14,6 +14,9 @@ import io.mockk.every
 import io.mockk.mockkObject
 import java.io.File
 import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 
 class GameResolverTest : FunSpec({
     beforeSpec {
@@ -110,6 +113,31 @@ class GameResolverTest : FunSpec({
         val result = GameResolver.resolve(listOf(1L, 2L))
 
         result shouldBe mapOf(1L to "Game One", 2L to "Game Two")
+        coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
+    }
+
+    test("If resolve is called concurrently while the catalog is stale, the refresh should still happen only once.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        var lastFetchedAt: Long? = null
+        coEvery { GameStore.lastFetchedAt() } answers { lastFetchedAt }
+        coEvery { DiscordGameApi.getDetectableGames() } coAnswers {
+            delay(50)
+            mapOf(1L to "Game One", 2L to "Game Two")
+        }
+        coEvery { GameStore.replaceAll(any(), any()) } coAnswers {
+            lastFetchedAt = secondArg<Long>()
+        }
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+        coEvery { GameStore.find(2L) } returns GameData(2L, "Game Two", System.currentTimeMillis())
+
+        coroutineScope {
+            val d1 = async { GameResolver.resolve(listOf(1L)) }
+            val d2 = async { GameResolver.resolve(listOf(2L)) }
+            d1.await()
+            d2.await()
+        }
+
         coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
     }
 })

--- a/src/test/kotlin/tools/discord/GameResolverTest.kt
+++ b/src/test/kotlin/tools/discord/GameResolverTest.kt
@@ -1,7 +1,6 @@
 package tools.discord
 
 import com.jaoafa.vcspeaker.VCSpeaker
-import com.jaoafa.vcspeaker.stores.GameData
 import com.jaoafa.vcspeaker.stores.GameStore
 import com.jaoafa.vcspeaker.tools.discord.DiscordGameApi
 import com.jaoafa.vcspeaker.tools.discord.GameResolver
@@ -41,7 +40,7 @@ class GameResolverTest : FunSpec({
         mockkObject(GameStore)
         mockkObject(DiscordGameApi)
         coEvery { GameStore.lastFetchedAt() } returns System.currentTimeMillis()
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+        coEvery { GameStore.findAll(setOf(1L)) } returns mapOf(1L to "Game One")
 
         val result = GameResolver.resolve(listOf(1L))
 
@@ -55,7 +54,7 @@ class GameResolverTest : FunSpec({
         coEvery { GameStore.lastFetchedAt() } returns null
         coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One")
         coEvery { GameStore.replaceAll(any(), any()) } returns Unit
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+        coEvery { GameStore.findAll(setOf(1L)) } returns mapOf(1L to "Game One")
 
         val result = GameResolver.resolve(listOf(1L))
 
@@ -70,7 +69,7 @@ class GameResolverTest : FunSpec({
         coEvery { GameStore.lastFetchedAt() } returns staleTimestamp
         coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One (Updated)")
         coEvery { GameStore.replaceAll(any(), any()) } returns Unit
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One (Updated)", System.currentTimeMillis())
+        coEvery { GameStore.findAll(setOf(1L)) } returns mapOf(1L to "Game One (Updated)")
 
         val result = GameResolver.resolve(listOf(1L))
 
@@ -85,7 +84,7 @@ class GameResolverTest : FunSpec({
         mockkObject(DiscordGameApi)
         coEvery { GameStore.lastFetchedAt() } returns staleTimestamp
         coEvery { DiscordGameApi.getDetectableGames() } returns null
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Old Game Name", staleTimestamp)
+        coEvery { GameStore.findAll(setOf(1L)) } returns mapOf(1L to "Old Game Name")
 
         val result = GameResolver.resolve(listOf(1L))
 
@@ -98,7 +97,7 @@ class GameResolverTest : FunSpec({
         mockkObject(DiscordGameApi)
         coEvery { GameStore.lastFetchedAt() } returns null
         coEvery { DiscordGameApi.getDetectableGames() } returns null
-        coEvery { GameStore.find(999L) } returns null
+        coEvery { GameStore.findAll(setOf(999L)) } returns emptyMap()
 
         val result = GameResolver.resolve(listOf(999L))
 
@@ -111,8 +110,7 @@ class GameResolverTest : FunSpec({
         coEvery { GameStore.lastFetchedAt() } returns null
         coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One", 2L to "Game Two")
         coEvery { GameStore.replaceAll(any(), any()) } returns Unit
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
-        coEvery { GameStore.find(2L) } returns GameData(2L, "Game Two", System.currentTimeMillis())
+        coEvery { GameStore.findAll(setOf(1L, 2L)) } returns mapOf(1L to "Game One", 2L to "Game Two")
 
         val result = GameResolver.resolve(listOf(1L, 2L))
 
@@ -132,8 +130,8 @@ class GameResolverTest : FunSpec({
         coEvery { GameStore.replaceAll(any(), any()) } coAnswers {
             lastFetchedAt = secondArg<Long>()
         }
-        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
-        coEvery { GameStore.find(2L) } returns GameData(2L, "Game Two", System.currentTimeMillis())
+        coEvery { GameStore.findAll(setOf(1L)) } returns mapOf(1L to "Game One")
+        coEvery { GameStore.findAll(setOf(2L)) } returns mapOf(2L to "Game Two")
 
         coroutineScope {
             val d1 = async { GameResolver.resolve(listOf(1L)) }
@@ -150,7 +148,7 @@ class GameResolverTest : FunSpec({
         mockkObject(DiscordGameApi)
         coEvery { GameStore.lastFetchedAt() } returns null
         coEvery { DiscordGameApi.getDetectableGames() } returns null
-        coEvery { GameStore.find(1L) } returns null
+        coEvery { GameStore.findAll(setOf(1L)) } returns emptyMap()
 
         GameResolver.resolve(listOf(1L))
         GameResolver.resolve(listOf(1L))

--- a/src/test/kotlin/tools/discord/GameResolverTest.kt
+++ b/src/test/kotlin/tools/discord/GameResolverTest.kt
@@ -31,6 +31,10 @@ class GameResolverTest : FunSpec({
     afterTest {
         clearAllMocks()
         GameStore.data.clear()
+
+        val field = GameResolver::class.java.getDeclaredField("refreshFailedUntil")
+        field.isAccessible = true
+        field.set(GameResolver, null)
     }
 
     test("If the catalog is fresh, DiscordGameApi should not be called.") {
@@ -137,6 +141,19 @@ class GameResolverTest : FunSpec({
             d1.await()
             d2.await()
         }
+
+        coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
+    }
+
+    test("If a refresh fails, the next resolve within the cooldown window should not retry the fetch.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns null
+        coEvery { DiscordGameApi.getDetectableGames() } returns null
+        coEvery { GameStore.find(1L) } returns null
+
+        GameResolver.resolve(listOf(1L))
+        GameResolver.resolve(listOf(1L))
 
         coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
     }

--- a/src/test/kotlin/tools/discord/GameResolverTest.kt
+++ b/src/test/kotlin/tools/discord/GameResolverTest.kt
@@ -1,0 +1,115 @@
+package tools.discord
+
+import com.jaoafa.vcspeaker.VCSpeaker
+import com.jaoafa.vcspeaker.stores.GameData
+import com.jaoafa.vcspeaker.stores.GameStore
+import com.jaoafa.vcspeaker.tools.discord.DiscordGameApi
+import com.jaoafa.vcspeaker.tools.discord.GameResolver
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockkObject
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+class GameResolverTest : FunSpec({
+    beforeSpec {
+        mockkObject(VCSpeaker)
+        every { VCSpeaker.storeFolder } returns File(System.getProperty("java.io.tmpdir") + File.separator + "vcspeaker-test-${System.currentTimeMillis()}")
+        VCSpeaker.storeFolder.mkdirs()
+
+        val gameFile = File(VCSpeaker.storeFolder, "games.json")
+        gameFile.writeText("""{"version":1,"list":[]}""")
+    }
+
+    afterTest {
+        clearAllMocks()
+        GameStore.data.clear()
+    }
+
+    test("If the catalog is fresh, DiscordGameApi should not be called.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns System.currentTimeMillis()
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+
+        val result = GameResolver.resolve(listOf(1L))
+
+        result shouldBe mapOf(1L to "Game One")
+        coVerify(exactly = 0) { DiscordGameApi.getDetectableGames() }
+    }
+
+    test("If the catalog has never been fetched, DiscordGameApi should be called.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns null
+        coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One")
+        coEvery { GameStore.replaceAll(any(), any()) } returns Unit
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+
+        val result = GameResolver.resolve(listOf(1L))
+
+        result shouldBe mapOf(1L to "Game One")
+        coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
+    }
+
+    test("If the catalog is stale, DiscordGameApi should be called and the store should be replaced.") {
+        val staleTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(91)
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns staleTimestamp
+        coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One (Updated)")
+        coEvery { GameStore.replaceAll(any(), any()) } returns Unit
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One (Updated)", System.currentTimeMillis())
+
+        val result = GameResolver.resolve(listOf(1L))
+
+        result shouldBe mapOf(1L to "Game One (Updated)")
+        coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
+        coVerify(exactly = 1) { GameStore.replaceAll(mapOf(1L to "Game One (Updated)"), any()) }
+    }
+
+    test("If the refresh fails and the id exists in the stale store, the stale name should be returned.") {
+        val staleTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(91)
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns staleTimestamp
+        coEvery { DiscordGameApi.getDetectableGames() } returns null
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Old Game Name", staleTimestamp)
+
+        val result = GameResolver.resolve(listOf(1L))
+
+        result shouldBe mapOf(1L to "Old Game Name")
+        coVerify(exactly = 0) { GameStore.replaceAll(any(), any()) }
+    }
+
+    test("If the refresh fails and the id does not exist in the store, it should be unresolved.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns null
+        coEvery { DiscordGameApi.getDetectableGames() } returns null
+        coEvery { GameStore.find(999L) } returns null
+
+        val result = GameResolver.resolve(listOf(999L))
+
+        result shouldBe mapOf(999L to null)
+    }
+
+    test("If multiple ids are requested, the catalog should be refreshed only once.") {
+        mockkObject(GameStore)
+        mockkObject(DiscordGameApi)
+        coEvery { GameStore.lastFetchedAt() } returns null
+        coEvery { DiscordGameApi.getDetectableGames() } returns mapOf(1L to "Game One", 2L to "Game Two")
+        coEvery { GameStore.replaceAll(any(), any()) } returns Unit
+        coEvery { GameStore.find(1L) } returns GameData(1L, "Game One", System.currentTimeMillis())
+        coEvery { GameStore.find(2L) } returns GameData(2L, "Game Two", System.currentTimeMillis())
+
+        val result = GameResolver.resolve(listOf(1L, 2L))
+
+        result shouldBe mapOf(1L to "Game One", 2L to "Game Two")
+        coVerify(exactly = 1) { DiscordGameApi.getDetectableGames() }
+    }
+})


### PR DESCRIPTION
## 概要

Discord のゲームメンション `<@$GAME_ID>` を、Discord の非公開 API `GET /api/v10/applications/detectable`(認証不要・全件一括取得)から解決したゲーム名で読み上げるようにします。

Closes #486

## 変更内容

- `GameMentionReplacer`: `<@$GAME_ID>` を検出し、`GameResolver` で解決したゲーム名(未解決時は「ゲーム」)に置換
- `GameResolver`: game ID → game name の解決を担当。`GameStore` の fresh/stale 判定(7日 TTL)、single-flight Mutex によるカタログ再取得の直列化、取得失敗時の cooldown を実装
- `DiscordGameApi`: `applications/detectable` との HTTP 通信のみを担当。認証ヘッダーなし、429/5xx/タイムアウト等の失敗時は例外を伝播させず null を返す
- `GameStore`: `id`/`name`/`updatedAt` を保存する `StoreStruct` ベースの永続キャッシュ

## テスト

- `GameStoreTest`, `GameResolverTest`, `GameMentionReplacerTest` を追加
- `./gradlew test` で全テストが成功することを確認済み

## 参考資料

Spec: https://github.com/jaoafa/VCSpeaker.kt/issues/486#issuecomment-5263609058
Plan: https://github.com/jaoafa/VCSpeaker.kt/issues/486#issuecomment-5264061567

🤖 Generated with [Claude Code](https://claude.com/claude-code)